### PR TITLE
[fix] correct resultTemplate docs for Toolbar search

### DIFF
--- a/docs/api/config/toolbar_items_config.md
+++ b/docs/api/config/toolbar_items_config.md
@@ -26,8 +26,8 @@ items?: [
                 }
             }, {...}
         ],
-        resultTemplate?: template(searchResult => {
-            return "The HTML template of the search result";
+        resultTemplate?: template(({ result }) => {
+            return `HTML template using ${result.label}`;
         }) 
     },
     "sort" | {
@@ -66,7 +66,7 @@ In the **items** array you can specify the following parameters:
         - ***card*** - an object of the card data
         - ***value*** - a searched value, specified in the search bar
         - ***by*** - a key of card field, by which the cards will be searched
-- `searchResult` - (optional) a template for displaying the custom search result
+- `resultTemplate` - (optional) a template for displaying the custom search result
 
 ~~~jsx
 items: [
@@ -93,10 +93,10 @@ items: [
                 }
             }
         ],
-        resultTemplate: kanban.template(searchResult => {
+        resultTemplate: kanban.template(({ result }) => {
             return `<div class="list-item">
-                <div class="list-item-text">${searchResult.result.label}</div>
-                ${searchResult.result.description ? `<div class="list-item-text item-description">${searchResult.result.description}</div>` : ""}
+                <div class="list-item-text">${result.label}</div>
+                ${result.description ? `<div class="list-item-text item-description">${result.description}</div>` : ""}
             </div>`
         })
     },
@@ -161,10 +161,10 @@ new kanban.Toolbar("#toolbar", {
     items: [
         {
             type: "search",
-            resultTemplate: kanban.template(searchResult => {
+            resultTemplate: kanban.template(({ result }) => {
                 return `<div class="list-item">
-                            <div class="list-item-text">${searchResult.result.label}</div>
-                            ${searchResult.result.description ? `<div class="list-item-text item-description">${searchResult.result.description}</div>` : ""}
+                            <div class="list-item-text">${result.label}</div>
+                            ${result.description ? `<div class="list-item-text item-description">${result.description}</div>` : ""}
                         </div>`
             })
         },
@@ -182,7 +182,7 @@ new kanban.Toolbar("#toolbar", {
 
 - The *"Undo"* and *"Redo"* controls were added in v1.3
 - The ***items.options[0].label*** parameter of the **sort** control was replaced by the ***items.options[0].text*** parameter in v1.4
-- The ***items.searchResult*** parameter of the **"search"** control was added in v1.6
+- The ***items.resultTemplate*** parameter of the **"search"** control was added in v1.6
 
 **Related articles:** [Configuration](guides/configuration.md#toolbar) and [Customization](guides/customization.md#custom-toolbar)
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -554,10 +554,10 @@ new kanban.Toolbar("#toolbar", {
                     }
                 }
             ],
-            resultTemplate: kanban.template(searchResult => {
+            resultTemplate: kanban.template(({ result }) => {
                 return `<div class="list-item">
-                            <div class="list-item-text">${searchResult.result.label}</div>
-                            ${searchResult.result.description ? `<div class="list-item-text item-description">${searchResult.result.description}</div>` : ""}
+                            <div class="list-item-text">${result.label}</div>
+                            ${result.description ? `<div class="list-item-text item-description">${result.description}</div>` : ""}
                         </div>`
             })
         },

--- a/docs/news/whats_new.md
+++ b/docs/news/whats_new.md
@@ -158,7 +158,7 @@ Released on November 13, 2024
 
 - The ability to change how many assigned users are displayed on a card via the [`cardShape.users.maxCount`](api/config/js_kanban_cardshape_config.md) property (see the [**example**](https://snippet.dhtmlx.com/w205dvzg?tag=kanban))
 - The ability to change the content of column headers via the [`columnShape`](api/config/js_kanban_columnshape_config.md) property (see the [**example**](https://snippet.dhtmlx.com/gq2saz9c?tag=kanban))
-- The ability to change the view and content of search results via the [`items.searchResult`](api/config/toolbar_items_config.md) property of the Toolbar **search** control (see the [**example**](https://snippet.dhtmlx.com/2uo2f5mf?tag=kanban))
+- The ability to change the view and content of search results via the [`items.resultTemplate`](api/config/toolbar_items_config.md) property of the Toolbar **search** control (see the [**example**](https://snippet.dhtmlx.com/2uo2f5mf?tag=kanban))
 - The ability to display the editor as a modal window via the [`editor.placement`](api/config/js_kanban_editor_config.md) property (see the [**example**](https://snippet.dhtmlx.com/vt6pe7qz?tag=kanban))
 - The ability to enable voting for a card (using the vote icon on the card) via the [`cardShape.votes.clickable`](api/config/js_kanban_cardshape_config.md) property (see the [**example**](https://snippet.dhtmlx.com/en76xvi4?tag=kanban))
 
@@ -169,7 +169,7 @@ Released on November 13, 2024
     - The [`cardShape`](api/config/js_kanban_cardshape_config.md) property is extended by the ***users.maxCount*** and ***votes.clickable*** parameters
     - The [`columnShape`](api/config/js_kanban_columnshape_config.md) property is extended by the ***headerTemplate*** and ***collapsedTemplate*** parameters
     - The [`editor`](api/config/js_kanban_editor_config.md) property is extended by the ***placement*** parameter
-    - The [`items`](api/config/toolbar_items_config.md) property of the Toolbar **search** control is extended by the ***searchResult*** parameter
+    - The [`items`](api/config/toolbar_items_config.md) property of the Toolbar **search** control is extended by the ***resultTemplate*** parameter
 
 - #### Events
 


### PR DESCRIPTION
- rename incorrect "searchResult" parameter to "resultTemplate"
- update callback signature to destructured ({ result }) form
- replace searchResult.result.* references with result.*
- affects toolbar items API ref, configuration guide and changelog