### PR TITLE
[add] editorShape.modalSection parameter docs

### DIFF
--- a/docs/api/config/js_kanban_editorshape_config.md
+++ b/docs/api/config/js_kanban_editorshape_config.md
@@ -19,6 +19,7 @@ editorShape?: [
         type: string, 
         key: string, 
         label?: string, 
+        modalSection?: "left" | "right",
         
         // for the "dateRange" type only
         key: {
@@ -182,6 +183,9 @@ In the Kanban editor you can use the following types of fields: **dateRange**, *
 ~~~
 
 - `label` - (optional) an editor field label
+- `modalSection` - (optional) defines in which column of the modal editor the field is placed. Applied only when the editor is shown as a modal window via the [`editor.placement: "modal"`](api/config/js_kanban_editor_config.md) property. The possible values are:
+    - `"left"` - the field is placed in the left column
+    - `"right"` - the field is placed in the right column (default)
 
 #### - Parameters for a "dateRange" type
 
@@ -466,6 +470,7 @@ new kanban.Kanban("#root", {
 
 - The ***dateRange*** type was added in v1.3
 - The ***comments*** and ***links*** types of editor, and ***format*** parameters were added in v1.4
+- The ***modalSection*** parameter was added in v1.6
 - The ***clearButton*** parameter was replaced with the ***clear*** parameter
 
 **Related articles:** [Configuration](guides/configuration.md/#editor)

--- a/docs/news/whats_new.md
+++ b/docs/news/whats_new.md
@@ -169,6 +169,7 @@ Released on November 13, 2024
     - The [`cardShape`](api/config/js_kanban_cardshape_config.md) property is extended by the ***users.maxCount*** and ***votes.clickable*** parameters
     - The [`columnShape`](api/config/js_kanban_columnshape_config.md) property is extended by the ***headerTemplate*** and ***collapsedTemplate*** parameters
     - The [`editor`](api/config/js_kanban_editor_config.md) property is extended by the ***placement*** parameter
+    - The [`editorShape`](api/config/js_kanban_editorshape_config.md) property is extended by the ***modalSection*** parameter
     - The [`items`](api/config/toolbar_items_config.md) property of the Toolbar **search** control is extended by the ***searchResult*** parameter
 
 - #### Events


### PR DESCRIPTION
- common parameter that places a control in the left or right column of a modal editor (right by default)
- works only with editor.placement: "modal"
- update Usage block, parameters list and change log in editorShape
- mention in whats_new under v1.6 release