### PR TITLE
[add] RestDataProvider methods documentation

### DIFF
--- a/docs/api/overview/internal_rest_overview.md
+++ b/docs/api/overview/internal_rest_overview.md
@@ -6,11 +6,15 @@ description: You can have an Internal RestDataProvider methods overview of JavaS
 
 # RestDataProvider methods
 
-| Name                                                         | Description                                                        |
-| ------------------------------------------------------------ | ------------------------------------------------------------------ |
-| [](api/provider/rest_methods/js_kanban_getcards_method.md)    | @getshort(api/provider/rest_methods/js_kanban_getcards_method.md)   |
-| [](api/provider/rest_methods/js_kanban_getcolumns_method.md)  | @getshort(api/provider/rest_methods/js_kanban_getcolumns_method.md) |
-| [](api/provider/rest_methods/js_kanban_getlinks_method.md)    | @getshort(api/provider/rest_methods/js_kanban_getlinks_method.md)   |
-| [](api/provider/rest_methods/js_kanban_getrows_method.md)     | @getshort(api/provider/rest_methods/js_kanban_getrows_method.md)    |
-| [](api/provider/rest_methods/js_kanban_getusers_method.md)    | @getshort(api/provider/rest_methods/js_kanban_getusers_method.md)   |
-| [](api/provider/rest_methods/js_kanban_send_method.md)        | @getshort(api/provider/rest_methods/js_kanban_send_method.md)       |
+| Name                                                            | Description                                                           |
+| --------------------------------------------------------------- | --------------------------------------------------------------------- |
+| [](api/provider/rest_methods/js_kanban_getcards_method.md)      | @getshort(api/provider/rest_methods/js_kanban_getcards_method.md)     |
+| [](api/provider/rest_methods/js_kanban_getcolumns_method.md)    | @getshort(api/provider/rest_methods/js_kanban_getcolumns_method.md)   |
+| [](api/provider/rest_methods/js_kanban_gethandlers_method.md)   | @getshort(api/provider/rest_methods/js_kanban_gethandlers_method.md)  |
+| [](api/provider/rest_methods/js_kanban_getidresolver_method.md) | @getshort(api/provider/rest_methods/js_kanban_getidresolver_method.md)|
+| [](api/provider/rest_methods/js_kanban_getlinks_method.md)      | @getshort(api/provider/rest_methods/js_kanban_getlinks_method.md)     |
+| [](api/provider/rest_methods/js_kanban_getqueue_method.md)      | @getshort(api/provider/rest_methods/js_kanban_getqueue_method.md)     |
+| [](api/provider/rest_methods/js_kanban_getrows_method.md)       | @getshort(api/provider/rest_methods/js_kanban_getrows_method.md)      |
+| [](api/provider/rest_methods/js_kanban_getusers_method.md)      | @getshort(api/provider/rest_methods/js_kanban_getusers_method.md)     |
+| [](api/provider/rest_methods/js_kanban_send_method.md)          | @getshort(api/provider/rest_methods/js_kanban_send_method.md)         |
+| [](api/provider/rest_methods/js_kanban_setheaders_method.md)    | @getshort(api/provider/rest_methods/js_kanban_setheaders_method.md)   |

--- a/docs/api/provider/rest_methods/js_kanban_gethandlers_method.md
+++ b/docs/api/provider/rest_methods/js_kanban_gethandlers_method.md
@@ -1,0 +1,54 @@
+---
+sidebar_label: getHandlers()
+title: getHandlers REST Method
+description: You can learn about the getHandlers REST method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+---
+
+# getHandlers()
+
+### Description
+
+@short: Returns the default action handlers used by RestDataProvider to send data operations to the server
+
+:::info
+The **getHandlers()** method is a part of the **RestDataProvider** service intended for working with server.
+:::
+
+### Usage
+
+~~~jsx {}
+getHandlers(): object;
+~~~
+
+### Returns
+
+The `getHandlers()` method returns an object that maps the [data operations supported by `RestDataProvider`](guides/working_with_server.md/#restdataprovider) to the requests that the provider sends to the server.
+
+The returned object is the default actions map used internally by `RestDataProvider`. Override this method to add custom handlers or replace the default ones with custom logic.
+
+### Example
+
+To extend the default handlers with custom ones, create a class that extends `RestDataProvider` and override `getHandlers()`. Always call `super.getHandlers()` from the override to keep the default handlers in place:
+
+~~~jsx {3-11}
+const url = "https://some_backend_url";
+
+class MyDataProvider extends kanban.RestDataProvider {
+    getHandlers() {
+        const handlers = super.getHandlers();
+        return {
+            ...handlers,
+            // custom or overridden handlers go here
+        };
+    }
+}
+
+const restProvider = new MyDataProvider(url);
+board.api.setNext(restProvider);
+~~~
+
+:::warning
+Do not copy the default handlers into the override manually. The contents of the default actions map may change between versions; calling `super.getHandlers()` guarantees that your custom handlers stay merged on top of the current defaults.
+:::
+
+**Related articles:** [Working with server](guides/working_with_server.md)

--- a/docs/api/provider/rest_methods/js_kanban_getidresolver_method.md
+++ b/docs/api/provider/rest_methods/js_kanban_getidresolver_method.md
@@ -1,0 +1,58 @@
+---
+sidebar_label: getIDResolver()
+title: getIDResolver REST Method
+description: You can learn about the getIDResolver REST method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+---
+
+# getIDResolver()
+
+### Description
+
+@short: Returns a function that resolves temporary client-side IDs to backend IDs
+
+:::info
+The `getIDResolver()` method is a part of the **RestDataProvider** service intended for working with server.
+:::
+
+### Usage
+
+~~~jsx {}
+getIDResolver(): (id: string | number, type: number) => string | number;
+~~~
+
+### Returns
+
+The method returns an `idResolver(id, type)` function:
+
+- `id` — the entity ID to resolve (a temporary client-side ID or a regular ID)
+- `type` — the model type the ID belongs to:
+    - `1` — card (`CardID`)
+    - `2` — row (`RowID`)
+    - `3` — column (`ColumnID`)
+    - `4` — link (`LinkID`)
+    - `5` — comment (`CommentID`)
+
+When the client creates a new entity (card, column, row, link, comment), `RestDataProvider` assigns it a temporary client-side ID and remembers the backend ID returned by the server. The `idResolver(id, type)` function returns the backend ID for any temporary ID it still holds. For IDs that already match the backend, the function returns them unchanged.
+
+### Example
+
+The most common use case is wiring `RestDataProvider` to `kanbanUpdates` in a multiuser setup so that server events targeted at backend IDs apply correctly to entities that still live on the client under temporary IDs:
+
+~~~jsx {6-9}
+const url = "https://some_backend_url";
+const restProvider = new kanban.RestDataProvider(url);
+
+// other initialization...
+
+const handlers = kanbanUpdates(
+    board.api,
+    restProvider.getIDResolver()
+);
+
+const events = new kanban.RemoteEvents(url + "/api/v1", token);
+events.on(handlers);
+~~~
+
+The same resolver function can be used inside custom handlers passed to `RemoteEvents.on()`. See [Customize server events](guides/working_with_server.md/#customize-server-events) for a complete example.
+
+**Related articles:** [Working with server: Multiuser backend](guides/working_with_server.md/#multiuser-backend)

--- a/docs/api/provider/rest_methods/js_kanban_getqueue_method.md
+++ b/docs/api/provider/rest_methods/js_kanban_getqueue_method.md
@@ -1,0 +1,34 @@
+---
+sidebar_label: getQueue()
+title: getQueue REST Method
+description: You can learn about the getQueue REST method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+---
+
+# getQueue()
+
+### Description
+
+@short: Returns the internal queue of actions that RestDataProvider processes
+
+:::info
+The `getQueue()` method is a part of the **RestDataProvider** service intended for working with server.
+:::
+
+### Usage
+
+~~~jsx {}
+getQueue(): object;
+~~~
+
+### Returns
+
+The method returns the internal `ActionQueue` instance used by `RestDataProvider` to process data operations sent to the server. The queue is responsible for:
+
+- buffering actions until pending requests resolve
+- assigning temporary client-side IDs to newly created entities and replacing them with backend IDs once the server responds
+
+The queue is used internally by other methods of `RestDataProvider`. The most common indirect use is via [`getIDResolver()`](api/provider/rest_methods/js_kanban_getidresolver_method.md), which is built on top of the queue's ID-resolution logic.
+
+You normally do not need to call `getQueue()` directly. Use this method only when you need fine-grained access to the queue (for example, when implementing advanced custom synchronization between the client and the server).
+
+**Related articles:** [Working with server](guides/working_with_server.md)

--- a/docs/api/provider/rest_methods/js_kanban_setheaders_method.md
+++ b/docs/api/provider/rest_methods/js_kanban_setheaders_method.md
@@ -1,0 +1,42 @@
+---
+sidebar_label: setHeaders()
+title: setHeaders REST Method
+description: You can learn about the setHeaders REST method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+---
+
+# setHeaders()
+
+### Description
+
+@short: Sets custom HTTP headers that RestDataProvider attaches to every request sent to the server
+
+:::info
+The `setHeaders()` method is a part of the **RestDataProvider** service intended for working with server.
+:::
+
+### Usage
+
+~~~jsx {}
+setHeaders(headers: object): void;
+~~~
+
+### Parameters
+
+- `headers` - (required) an object whose keys are header names and values are header values. The headers are appended to the default `Content-Type: application/json` header on every request sent via [`send()`](api/provider/rest_methods/js_kanban_send_method.md).
+
+### Example
+
+The most common use case is attaching an authorization token to every request:
+
+~~~jsx {4-6}
+const url = "https://some_backend_url";
+const restProvider = new kanban.RestDataProvider(url);
+
+restProvider.setHeaders({
+    "Remote-Token": "eyJpZCI6IjEzMzciLCJ1c2VybmFtZSI6ImJpem9uZSIsImlhdC...",
+});
+~~~
+
+To set headers only for a particular request rather than for every request, pass them as the fourth argument to [`send()`](api/provider/rest_methods/js_kanban_send_method.md) instead.
+
+**Related articles:** [Working with server: Multiuser backend](guides/working_with_server.md/#multiuser-backend)

--- a/docs/guides/working_with_server.md
+++ b/docs/guides/working_with_server.md
@@ -38,14 +38,47 @@ JavaScript Kanban includes the `RestDataProvider` service, which fully supports 
 
 ## REST methods
 
-The `RestDataProvider` service exposes the following REST methods for dynamic data loading:
+The `RestDataProvider` service exposes the following REST methods:
 
 - [`getCards()`](api/provider/rest_methods/js_kanban_getcards_method.md) — gets a promise with cards data
 - [`getColumns()`](api/provider/rest_methods/js_kanban_getcolumns_method.md) — gets a promise with columns data
+- [`getHandlers()`](api/provider/rest_methods/js_kanban_gethandlers_method.md) — returns the default action handlers used by the provider
+- [`getIDResolver()`](api/provider/rest_methods/js_kanban_getidresolver_method.md) — returns a function that resolves temporary client IDs to backend IDs
 - [`getLinks()`](api/provider/rest_methods/js_kanban_getlinks_method.md) — gets a promise with links data
+- [`getQueue()`](api/provider/rest_methods/js_kanban_getqueue_method.md) — returns the internal queue of actions processed by the provider
 - [`getRows()`](api/provider/rest_methods/js_kanban_getrows_method.md) — gets a promise with rows data
 - [`getUsers()`](api/provider/rest_methods/js_kanban_getusers_method.md) — gets a promise with users data
 - [`send()`](api/provider/rest_methods/js_kanban_send_method.md) — sends a custom HTTP request and returns a promise
+- [`setHeaders()`](api/provider/rest_methods/js_kanban_setheaders_method.md) — sets custom HTTP headers attached to every request
+
+## Customize RestDataProvider
+
+To customize how `RestDataProvider` sends data operations to the server, extend the class and override one of its methods. Most often, customization targets the default action handlers — for example, to add a handler for a custom event or to extend the payload of an existing operation.
+
+To add custom handlers without losing the default ones, override [`getHandlers()`](api/provider/rest_methods/js_kanban_gethandlers_method.md) and merge custom entries on top of `super.getHandlers()`:
+
+~~~js {3-11}
+const url = "https://some_backend_url";
+
+class MyDataProvider extends kanban.RestDataProvider {
+    getHandlers() {
+        const handlers = super.getHandlers();
+        return {
+            ...handlers,
+            // custom or overridden handlers go here
+        };
+    }
+}
+
+const restProvider = new MyDataProvider(url);
+board.api.setNext(restProvider);
+~~~
+
+:::warning
+Always call `super.getHandlers()` from the override and spread its result. Do not copy the default handlers into the override manually — the actions map may change between versions, so a hard-coded copy can silently get out of sync with the current defaults.
+:::
+
+Another common customization target is the [`send()`](api/provider/rest_methods/js_kanban_send_method.md) method, which is called by every default handler. Override `send()` to inject extra headers, rewrite URLs, or wrap every server request with custom logic.
 
 ## Interact with the backend
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -322,10 +322,14 @@ module.exports = {
                                     items: [
                                         "api/provider/rest_methods/js_kanban_getcards_method",
                                         "api/provider/rest_methods/js_kanban_getcolumns_method",
+                                        "api/provider/rest_methods/js_kanban_gethandlers_method",
+                                        "api/provider/rest_methods/js_kanban_getidresolver_method",
                                         "api/provider/rest_methods/js_kanban_getlinks_method",
+                                        "api/provider/rest_methods/js_kanban_getqueue_method",
                                         "api/provider/rest_methods/js_kanban_getrows_method",
                                         "api/provider/rest_methods/js_kanban_getusers_method",
-                                        "api/provider/rest_methods/js_kanban_send_method"
+                                        "api/provider/rest_methods/js_kanban_send_method",
+                                        "api/provider/rest_methods/js_kanban_setheaders_method"
                                     ]
                                 }        
                             ]


### PR DESCRIPTION
- new reference pages: getHandlers, setHeaders, getQueue, getIDResolver
- internal_rest_overview index extended with new entries
- working_with_server guide: list of REST methods updated and a new "Customize RestDataProvider" section with the super.getHandlers() override pattern and a warning against copying default handlers
- sidebars.js updated with the four new pages