### PR TITLE
[update] clarify parse() as setConfig() alias

### DIFF
--- a/docs/api/methods/js_kanban_parse_method.md
+++ b/docs/api/methods/js_kanban_parse_method.md
@@ -13,7 +13,7 @@ description: You can learn about the parse method in the documentation of the DH
 The `parse()` method is an alias for [`setConfig()`](/api/methods/js_kanban_setconfig_method) restricted to data-related properties (`cards`, `columns`, `rows`, `links`). Both methods perform the same operation under the hood for these properties.
 
 :::tip Prefer setConfig()
-Use [`setConfig()`](/api/methods/js_kanban_setconfig_method) that accepts the same data properties **plus** every other Kanban configuration option. The method allows you to apply data together with related settings (such as [`columnKey`](api/config/js_kanban_columnkey_config.md), [`rowKey`](api/config/js_kanban_rowkey_config.md), [`cardShape`](api/config/js_kanban_cardshape_config.md)) in a single call, instead of chaining `setConfig()` and `parse()`:
+Use the [`setConfig()`](/api/methods/js_kanban_setconfig_method) method that accepts the same data properties **plus** other Kanban configuration option. Call `setConfig()` once for all props instead of calling `parse()` for data and `setConfig()` for the other props (such as [`columnKey`](api/config/js_kanban_columnkey_config.md), [`rowKey`](api/config/js_kanban_rowkey_config.md), [`cardShape`](api/config/js_kanban_cardshape_config.md)):
 
 ~~~js
 // instead of two calls

--- a/docs/api/methods/js_kanban_parse_method.md
+++ b/docs/api/methods/js_kanban_parse_method.md
@@ -10,7 +10,23 @@ description: You can learn about the parse method in the documentation of the DH
 
 @short: Parses data into Kanban
 
-This method performs the same operation as [`setConfig`](/api/methods/js_kanban_setconfig_method) when used with data-related Kanban settings. It is therefore recommended to use `setConfig` for consistency with other configuration options, although `parse` remains supported as an alias for data parsing.
+The `parse()` method is an alias for [`setConfig()`](/api/methods/js_kanban_setconfig_method) restricted to data-related properties (`cards`, `columns`, `rows`, `links`). Both methods perform the same operation under the hood for these properties.
+
+:::tip Prefer setConfig()
+Use [`setConfig()`](/api/methods/js_kanban_setconfig_method) that accepts the same data properties **plus** every other Kanban configuration option. The method allows you to apply data together with related settings (such as [`columnKey`](api/config/js_kanban_columnkey_config.md), [`rowKey`](api/config/js_kanban_rowkey_config.md), [`cardShape`](api/config/js_kanban_cardshape_config.md)) in a single call, instead of chaining `setConfig()` and `parse()`:
+
+~~~js
+// instead of two calls
+kanban.setConfig({ columnKey: "type" });
+kanban.parse({ columns });
+
+// use one
+kanban.setConfig({
+    columnKey: "type",
+    columns
+});
+~~~
+:::
 
 ### Usage
 
@@ -42,6 +58,9 @@ board.parse({
     rows,
     links
 });
+
+// equivalent call via setConfig()
+// board.setConfig({ columns, cards, rows, links });
 ~~~
 
 **Change log:** Starting from v1.1 you don't need to reset initial data in constructor before parsing new data

--- a/docs/howtos.md
+++ b/docs/howtos.md
@@ -61,7 +61,7 @@ In these sections you can find out how to perform operations with cards, work wi
 | [Getting cards state](api/internal/js_kanban_getstate_method.md) | Learn how to get the cards state                 |
 | [Getting cards reactive state](api/internal/js_kanban_getreactivestate_method.md) | Learn how to get the cards reactive state |
 | [Loading card data](api/config/js_kanban_cards_config.md)    | Learn how to load the initial card data             |
-| [Parsing card data](api/methods/js_kanban_parse_method.md)   | Learn how to parse the card data                    |
+| [Loading card data dynamically](api/methods/js_kanban_setconfig_method.md)   | Learn how to load card data at runtime via `setConfig()` (or its alias [`parse()`](api/methods/js_kanban_parse_method.md))|
 | [Serializing card data](api/methods/js_kanban_serialize_method.md)| Learn how to serialize the card data ([Example](https://snippet.dhtmlx.com/61crsls3?tag=kanban))|
 | [Updating card data](api/methods/js_kanban_updatecard_method.md)| Learn how to update the card data                |
 
@@ -117,7 +117,7 @@ In these sections you can find out how to perform operations with columns and wo
 | [Getting columns state](api/internal/js_kanban_getstate_method.md) | Learn how to get the columns state               |
 | [Getting columns reactive state](api/internal/js_kanban_getreactivestate_method.md) | Learn how to get the columns reactive state |
 | [Loading column data](api/config/js_kanban_columns_config.md)    | Learn how to load the initial column data          |
-| [Parsing column data](api/methods/js_kanban_parse_method.md)     | Learn how to parse the column data                 |
+| [Loading column data dynamically](api/methods/js_kanban_setconfig_method.md)     | Learn how to load column data at runtime via `setConfig()` (or its alias [`parse()`](api/methods/js_kanban_parse_method.md))|
 | [Serializing column data](api/methods/js_kanban_serialize_method.md)| Learn how to serialize the column data          |
 | [Updating column data](api/methods/js_kanban_updatecolumn_method.md)| Learn how to update the column data             |
 
@@ -143,7 +143,7 @@ In these sections you can find out how to perform operations with rows and work 
 | [Getting rows state](api/internal/js_kanban_getstate_method.md) | Learn how to get the rows state                     |
 | [Getting rows reactive state](api/internal/js_kanban_getreactivestate_method.md) | Learn how to get the rows reactive state |
 | [Loading row data](api/config/js_kanban_rows_config.md)         | Learn how to load the initial row data              |
-| [Parsing row data](api/methods/js_kanban_parse_method.md)       | Learn how to parse the row data                     |
+| [Loading row data dynamically](api/methods/js_kanban_setconfig_method.md)       | Learn how to load row data at runtime via `setConfig()` (or its alias [`parse()`](api/methods/js_kanban_parse_method.md))|
 | [Serializing row data](api/methods/js_kanban_serialize_method.md)| Learn how to serialize the row data                |
 | [Updating row data](api/methods/js_kanban_updaterow_method.md)  | Learn how to update the row data                    |
 


### PR DESCRIPTION
- parse() docs reframed as alias for setConfig() restricted to data properties, with a tip recommending setConfig() for combined data+config calls
- howtos: rename "Parsing X data" rows to "Loading X data dynamically", pointing to setConfig() with parse() noted as alias