### PR TITLE
[update] expand image alt descriptions in docs

### DIFF
--- a/docs/guides/integration_with_angular.md
+++ b/docs/guides/integration_with_angular.md
@@ -379,7 +379,7 @@ import trial from '@site/static/img/trial_kanban.png';
 
 <img
   src={trial}
-  alt="Kanban with Angular"
+  alt="DHTMLX Kanban board initialized inside an Angular application with populated columns and cards"
   className="img_border"
 />
 

--- a/docs/guides/integration_with_react.md
+++ b/docs/guides/integration_with_react.md
@@ -329,7 +329,7 @@ import trial from '@site/static/img/trial_kanban.png';
 
 <img
   src={trial}
-  alt="Kanban with React"
+  alt="DHTMLX Kanban board initialized inside a React application with populated columns and cards"
   className="img_border"
 />
 

--- a/docs/guides/integration_with_svelte.md
+++ b/docs/guides/integration_with_svelte.md
@@ -335,7 +335,7 @@ import trial from '@site/static/img/trial_kanban.png';
 
 <img
   src={trial}
-  alt="Kanban with Svelte"
+  alt="DHTMLX Kanban board initialized inside a Svelte application with populated columns and cards"
   className="img_border"
 />
 

--- a/docs/guides/integration_with_vue.md
+++ b/docs/guides/integration_with_vue.md
@@ -358,7 +358,7 @@ import trial from '@site/static/img/trial_kanban.png';
 
 <img
   src={trial}
-  alt="Kanban with Vue"
+  alt="DHTMLX Kanban board initialized inside a Vue application with populated columns and cards"
   className="img_border"
 />
 

--- a/docs/how_to_start.md
+++ b/docs/how_to_start.md
@@ -12,7 +12,7 @@ import editor from '@site/static/img/js_kanban_editor.png';
 
 <img
   src={editor}
-  alt="JS Kanban Main"
+  alt="DHTMLX JavaScript Kanban main view with toolbar, board, columns, swimlanes, and cards"
   className="img_border"
 />
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ import toolbar from '@site/static/img/js_kanban_toolbar.png';
 
 <img
   src={toolbar}
-  alt="Kanban Toolbar"
+  alt="DHTMLX Kanban toolbar with search field, sort control, undo/redo buttons, and controls for adding columns and rows"
   className="img_border"
 />
 
@@ -52,7 +52,7 @@ import board from '@site/static/img/js_kanban_board.png';
 
 <img
   src={board}
-  alt="Kanban Board"
+  alt="DHTMLX Kanban board with cards distributed across columns and swimlanes"
   className="img_border"
 />
 
@@ -64,7 +64,7 @@ import editor from '@site/static/img/js_kanban_editor.png';
 
 <img
   src={editor}
-  alt="Kanban Editor"
+  alt="DHTMLX Kanban card editor modal with fields and controls for managing the selected card data"
   className="img_border"
 />
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/integration_with_angular.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/integration_with_angular.md
@@ -379,7 +379,7 @@ import trial from '@site/static/img/trial_kanban.png';
 
 <img
   src={trial}
-  alt="Kanban mit Angular"
+  alt="DHTMLX Kanban Board, das in einer Angular-Anwendung initialisiert wurde, mit gefüllten Spalten und Karten"
   className="img_border"
 />
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/integration_with_react.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/integration_with_react.md
@@ -329,7 +329,7 @@ import trial from '@site/static/img/trial_kanban.png';
 
 <img
   src={trial}
-  alt="Kanban mit React"
+  alt="DHTMLX Kanban Board, das in einer React-Anwendung initialisiert wurde, mit gefüllten Spalten und Karten"
   className="img_border"
 />
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/integration_with_svelte.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/integration_with_svelte.md
@@ -335,7 +335,7 @@ import trial from '@site/static/img/trial_kanban.png';
 
 <img
   src={trial}
-  alt="Kanban mit Svelte"
+  alt="DHTMLX Kanban Board, das in einer Svelte-Anwendung initialisiert wurde, mit gefüllten Spalten und Karten"
   className="img_border"
 />
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/integration_with_vue.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/integration_with_vue.md
@@ -358,7 +358,7 @@ import trial from '@site/static/img/trial_kanban.png';
 
 <img
   src={trial}
-  alt="Kanban mit Vue"
+  alt="DHTMLX Kanban Board, das in einer Vue-Anwendung initialisiert wurde, mit gefüllten Spalten und Karten"
   className="img_border"
 />
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/how_to_start.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/how_to_start.md
@@ -12,7 +12,7 @@ import editor from '@site/static/img/js_kanban_editor.png';
 
 <img
     src={editor}
-    alt="JS Kanban Main"
+    alt="Gesamtansicht von DHTMLX JavaScript Kanban mit Toolbar, Board, Spalten, Swimlanes und Karten"
     className="img_border"
 />
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/index.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/index.md
@@ -19,7 +19,7 @@ import toolbar from '@site/static/img/js_kanban_toolbar.png';
 
 <img
     src={toolbar}
-    alt="Kanban Toolbar"
+    alt="DHTMLX Kanban Toolbar mit Suchleiste, Sortiersteuerung, Undo/Redo-Schaltflächen sowie Steuerelementen zum Hinzufügen von Spalten und Zeilen"
     className="img_border"
 />
 
@@ -52,7 +52,7 @@ import board from '@site/static/img/js_kanban_board.png';
 
 <img
     src={board}
-    alt="Kanban Board"
+    alt="DHTMLX Kanban Board mit Karten, die auf Spalten und Swimlanes verteilt sind"
     className="img_border"
 />
 
@@ -64,7 +64,7 @@ import editor from '@site/static/img/js_kanban_editor.png';
 
 <img
     src={editor}
-    alt="Kanban Editor"
+    alt="Modaler Karten-Editor von DHTMLX Kanban mit Feldern und Steuerelementen zur Verwaltung der ausgewählten Kartendaten"
     className="img_border"
 />
 

--- a/i18n/ko/docusaurus-plugin-content-docs/current/guides/integration_with_angular.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/guides/integration_with_angular.md
@@ -379,7 +379,7 @@ import trial from '@site/static/img/trial_kanban.png';
 
 <img
   src={trial}
-  alt="Kanban with Angular"
+  alt="Angular 애플리케이션에서 초기화되어 컬럼과 카드가 채워진 DHTMLX Kanban 보드"
   className="img_border"
 />
 

--- a/i18n/ko/docusaurus-plugin-content-docs/current/guides/integration_with_react.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/guides/integration_with_react.md
@@ -329,7 +329,7 @@ import trial from '@site/static/img/trial_kanban.png';
 
 <img
   src={trial}
-  alt="Kanban with React"
+  alt="React 애플리케이션에서 초기화되어 컬럼과 카드가 채워진 DHTMLX Kanban 보드"
   className="img_border"
 />
 

--- a/i18n/ko/docusaurus-plugin-content-docs/current/guides/integration_with_svelte.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/guides/integration_with_svelte.md
@@ -335,7 +335,7 @@ import trial from '@site/static/img/trial_kanban.png';
 
 <img
   src={trial}
-  alt="Kanban with Svelte"
+  alt="Svelte 애플리케이션에서 초기화되어 컬럼과 카드가 채워진 DHTMLX Kanban 보드"
   className="img_border"
 />
 

--- a/i18n/ko/docusaurus-plugin-content-docs/current/guides/integration_with_vue.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/guides/integration_with_vue.md
@@ -358,7 +358,7 @@ import trial from '@site/static/img/trial_kanban.png';
 
 <img
   src={trial}
-  alt="Kanban with Vue"
+  alt="Vue 애플리케이션에서 초기화되어 컬럼과 카드가 채워진 DHTMLX Kanban 보드"
   className="img_border"
 />
 

--- a/i18n/ko/docusaurus-plugin-content-docs/current/how_to_start.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/how_to_start.md
@@ -12,7 +12,7 @@ import editor from '@site/static/img/js_kanban_editor.png';
 
 <img
     src={editor}
-    alt="JS Kanban Main"
+    alt="Toolbar, Board, 컬럼, 스윔레인, 카드를 포함한 DHTMLX JavaScript Kanban 전체 화면"
     className="img_border"
 />
 

--- a/i18n/ko/docusaurus-plugin-content-docs/current/index.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/index.md
@@ -19,7 +19,7 @@ import toolbar from '@site/static/img/js_kanban_toolbar.png';
 
 <img
     src={toolbar}
-    alt="Kanban Toolbar"
+    alt="검색창, 정렬 컨트롤, undo/redo 버튼, 컬럼 및 행 추가 컨트롤이 포함된 DHTMLX Kanban Toolbar"
     className="img_border"
 />
 
@@ -52,7 +52,7 @@ import board from '@site/static/img/js_kanban_board.png';
 
 <img
     src={board}
-    alt="Kanban Board"
+    alt="컬럼과 스윔레인에 카드가 배치된 DHTMLX Kanban Board"
     className="img_border"
 />
 
@@ -64,7 +64,7 @@ import editor from '@site/static/img/js_kanban_editor.png';
 
 <img
     src={editor}
-    alt="Kanban Editor"
+    alt="선택한 카드 데이터를 관리할 수 있는 필드와 컨트롤로 구성된 DHTMLX Kanban 카드 에디터 모달"
     className="img_border"
 />
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/integration_with_angular.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/integration_with_angular.md
@@ -379,7 +379,7 @@ import trial from '@site/static/img/trial_kanban.png';
 
 <img
   src={trial}
-  alt="Kanban with Angular"
+  alt="Доска DHTMLX Kanban, инициализированная в приложении Angular, с заполненными колонками и карточками"
   className="img_border"
 />
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/integration_with_react.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/integration_with_react.md
@@ -329,7 +329,7 @@ import trial from '@site/static/img/trial_kanban.png';
 
 <img
   src={trial}
-  alt="Kanban with React"
+  alt="Доска DHTMLX Kanban, инициализированная в приложении React, с заполненными колонками и карточками"
   className="img_border"
 />
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/integration_with_svelte.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/integration_with_svelte.md
@@ -335,7 +335,7 @@ import trial from '@site/static/img/trial_kanban.png';
 
 <img
   src={trial}
-  alt="Kanban with Svelte"
+  alt="Доска DHTMLX Kanban, инициализированная в приложении Svelte, с заполненными колонками и карточками"
   className="img_border"
 />
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/integration_with_vue.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/integration_with_vue.md
@@ -358,7 +358,7 @@ import trial from '@site/static/img/trial_kanban.png';
 
 <img
   src={trial}
-  alt="Kanban with Vue"
+  alt="Доска DHTMLX Kanban, инициализированная в приложении Vue, с заполненными колонками и карточками"
   className="img_border"
 />
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/how_to_start.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/how_to_start.md
@@ -12,7 +12,7 @@ import editor from '@site/static/img/js_kanban_editor.png';
 
 <img
     src={editor}
-    alt="JS Kanban Main"
+    alt="Общий вид DHTMLX JavaScript Kanban с панелью инструментов, доской, колонками, дорожками (swimlanes) и карточками"
     className="img_border"
 />
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/index.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/index.md
@@ -19,7 +19,7 @@ import toolbar from '@site/static/img/js_kanban_toolbar.png';
 
 <img
     src={toolbar}
-    alt="Kanban Toolbar"
+    alt="Панель инструментов DHTMLX Kanban с полем поиска, сортировкой, кнопками отмены/повтора и элементами для добавления колонок и строк"
     className="img_border"
 />
 
@@ -52,7 +52,7 @@ import board from '@site/static/img/js_kanban_board.png';
 
 <img
     src={board}
-    alt="Kanban Board"
+    alt="Доска DHTMLX Kanban с карточками, распределёнными по колонкам и дорожкам (swimlanes)"
     className="img_border"
 />
 
@@ -64,7 +64,7 @@ import editor from '@site/static/img/js_kanban_editor.png';
 
 <img
     src={editor}
-    alt="Kanban Editor"
+    alt="Модальный редактор карточки DHTMLX Kanban с полями и элементами управления для редактирования данных выбранной карточки"
     className="img_border"
 />
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/guides/integration_with_angular.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/guides/integration_with_angular.md
@@ -379,7 +379,7 @@ import trial from '@site/static/img/trial_kanban.png';
 
 <img
   src={trial}
-  alt="Kanban with Angular"
+  alt="在 Angular 应用中初始化的 DHTMLX Kanban 看板，包含已填充的列和卡片"
   className="img_border"
 />
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/guides/integration_with_react.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/guides/integration_with_react.md
@@ -329,7 +329,7 @@ import trial from '@site/static/img/trial_kanban.png';
 
 <img
   src={trial}
-  alt="Kanban with React"
+  alt="在 React 应用中初始化的 DHTMLX Kanban 看板，包含已填充的列和卡片"
   className="img_border"
 />
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/guides/integration_with_svelte.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/guides/integration_with_svelte.md
@@ -335,7 +335,7 @@ import trial from '@site/static/img/trial_kanban.png';
 
 <img
   src={trial}
-  alt="Kanban with Svelte"
+  alt="在 Svelte 应用中初始化的 DHTMLX Kanban 看板，包含已填充的列和卡片"
   className="img_border"
 />
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/guides/integration_with_vue.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/guides/integration_with_vue.md
@@ -358,7 +358,7 @@ import trial from '@site/static/img/trial_kanban.png';
 
 <img
   src={trial}
-  alt="Kanban with Vue"
+  alt="在 Vue 应用中初始化的 DHTMLX Kanban 看板，包含已填充的列和卡片"
   className="img_border"
 />
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/how_to_start.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/how_to_start.md
@@ -12,7 +12,7 @@ import editor from '@site/static/img/js_kanban_editor.png';
 
 <img
     src={editor}
-    alt="JS Kanban Main"
+    alt="DHTMLX JavaScript Kanban 总览，包含工具栏、看板、列、泳道和卡片"
     className="img_border"
 />
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/index.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/index.md
@@ -19,7 +19,7 @@ import toolbar from '@site/static/img/js_kanban_toolbar.png';
 
 <img
     src={toolbar}
-    alt="Kanban Toolbar"
+    alt="DHTMLX Kanban 工具栏，包含搜索栏、排序控件、撤销/重做按钮以及添加列和行的控件"
     className="img_border"
 />
 
@@ -52,7 +52,7 @@ import board from '@site/static/img/js_kanban_board.png';
 
 <img
     src={board}
-    alt="Kanban Board"
+    alt="DHTMLX Kanban 看板，卡片按列和泳道分布"
     className="img_border"
 />
 
@@ -64,7 +64,7 @@ import editor from '@site/static/img/js_kanban_editor.png';
 
 <img
     src={editor}
-    alt="Kanban Editor"
+    alt="DHTMLX Kanban 卡片编辑器模态窗口，包含用于管理所选卡片数据的字段和控件"
     className="img_border"
 />
 


### PR DESCRIPTION
- replace short labels with descriptive alt text for all 8 images in EN docs
- mirror updates across ru, zh, de, ko locales for a11y and SEO