### PR TITLE
[update] normalize SEO titles and meta descriptions

### DIFF
--- a/docs/api/common/js_kanban_meta_parameter.md
+++ b/docs/api/common/js_kanban_meta_parameter.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: $meta
 title: $meta Parameter API
-description: You can learn about the $meta parameter in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the $meta parameter API for DHTMLX Kanban. Learn how to pass extra settings for configuring methods and events.
 ---
 
 # $meta

--- a/docs/api/common/js_kanban_meta_parameter.md
+++ b/docs/api/common/js_kanban_meta_parameter.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: $meta
-title: $meta parameter
+title: $meta Parameter API
 description: You can learn about the $meta parameter in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/config/js_kanban_cardheight_config.md
+++ b/docs/api/config/js_kanban_cardheight_config.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: cardHeight
-title: cardHeight Config
-description: You can learn about the cardHeight config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: cardHeight Config API
+description: Read the cardHeight configuration API for DHTMLX Kanban. Learn how fixed card height supports layout and lazy rendering.
 ---
 
 # cardHeight

--- a/docs/api/config/js_kanban_cards_config.md
+++ b/docs/api/config/js_kanban_cards_config.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: cards
-title: cards Config
-description: You can learn about the cards config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: cards Config API
+description: Read the cards configuration API for DHTMLX Kanban. Learn how to define task card data, fields, statuses, and board content.
 ---
 
 # cards

--- a/docs/api/config/js_kanban_cardshape_config.md
+++ b/docs/api/config/js_kanban_cardshape_config.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: cardShape
-title: cardShape Config
-description: You can learn about the cardShape config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: cardShape Config API
+description: Read the cardShape configuration API for DHTMLX Kanban. Learn how to control card fields, layout, menus, and visual card options.
 ---
 
 # cardShape

--- a/docs/api/config/js_kanban_cardtemplate_config.md
+++ b/docs/api/config/js_kanban_cardtemplate_config.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: cardTemplate
-title: cardTemplate Config
-description: You can learn about the cardTemplate config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: cardTemplate Config API
+description: Read the cardTemplate configuration documentation for DHTMLX Kanban. Learn how to create custom HTML templates for task cards.
 ---
 
 # cardTemplate

--- a/docs/api/config/js_kanban_columnkey_config.md
+++ b/docs/api/config/js_kanban_columnkey_config.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: columnKey
 title: columnKey Config API
-description: You can learn about the columnKey config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the columnKey configuration API for DHTMLX Kanban. Learn how to bind cards to columns by a custom data key.
 ---
 
 # columnKey

--- a/docs/api/config/js_kanban_columnkey_config.md
+++ b/docs/api/config/js_kanban_columnkey_config.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: columnKey
-title: columnKey Config
+title: columnKey Config API
 description: You can learn about the columnKey config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/config/js_kanban_columns_config.md
+++ b/docs/api/config/js_kanban_columns_config.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: columns
-title: columns Config
-description: You can learn about the columns config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: columns Config API
+description: Read the columns configuration documentation for DHTMLX Kanban. Learn how to set column IDs, labels, layout, and workflow structure.
 ---
 
 # columns

--- a/docs/api/config/js_kanban_columnshape_config.md
+++ b/docs/api/config/js_kanban_columnshape_config.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: columnShape
-title: columnShape Config
-description: You can learn about the columnShape config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: columnShape Config API
+description: Read the columnShape configuration API for DHTMLX Kanban. Learn how to customize column headers, menus, and appearance.
 ---
 
 # columnShape

--- a/docs/api/config/js_kanban_currentuser_config.md
+++ b/docs/api/config/js_kanban_currentuser_config.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: currentUser
-title: currentUser Config
-description: You can learn about the currentUser config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: currentUser Config API
+description: Read the currentUser configuration API for DHTMLX Kanban. Learn how to set active users for comments, votes, and collaboration.
 ---
 
 # currentUser

--- a/docs/api/config/js_kanban_editor_config.md
+++ b/docs/api/config/js_kanban_editor_config.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: editor
-title: editor Config
-description: You can learn about the editor config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: editor Config API
+description: Read the editor configuration documentation for DHTMLX Kanban. Learn how to enable, customize, and control task editor behavior.
 ---
 
 # editor

--- a/docs/api/config/js_kanban_editorautosave_config.md
+++ b/docs/api/config/js_kanban_editorautosave_config.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: editorAutoSave
-title: editorAutoSave Config
+title: editorAutoSave Config API
 description: You can learn about the editorAutoSave config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/config/js_kanban_editorautosave_config.md
+++ b/docs/api/config/js_kanban_editorautosave_config.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: editorAutoSave
 title: editorAutoSave Config API
-description: You can learn about the editorAutoSave config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the editorAutoSave configuration API for DHTMLX Kanban. Learn how to enable or disable autosave in the card editor.
 ---
 
 # 

--- a/docs/api/config/js_kanban_editorshape_config.md
+++ b/docs/api/config/js_kanban_editorshape_config.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: editorShape
-title: editorShape Config
-description: You can learn about the editorShape config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: editorShape Config API
+description: Read the editorShape configuration documentation for DHTMLX Kanban. Learn how to define editor fields, controls, and task editing behavior.
 ---
 
 # editorShape

--- a/docs/api/config/js_kanban_getcardheight_config.md
+++ b/docs/api/config/js_kanban_getcardheight_config.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: getCardHeight
-title: getCardHeight Config
+title: getCardHeight Config API
 description: You can learn about the getCardHeight config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/config/js_kanban_getcardheight_config.md
+++ b/docs/api/config/js_kanban_getcardheight_config.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: getCardHeight
 title: getCardHeight Config API
-description: You can learn about the getCardHeight config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the getCardHeight configuration API for DHTMLX Kanban. Learn how to set a function that returns an estimated card height.
 ---
 
 # getCardHeight

--- a/docs/api/config/js_kanban_history_config.md
+++ b/docs/api/config/js_kanban_history_config.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: history
-title: history Config
+title: history Config API
 description: You can learn about the history config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/config/js_kanban_history_config.md
+++ b/docs/api/config/js_kanban_history_config.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: history
 title: history Config API
-description: You can learn about the history config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the history configuration API for DHTMLX Kanban. Learn how to enable or disable undo/redo history of changes.
 ---
 
 # history

--- a/docs/api/config/js_kanban_links_config.md
+++ b/docs/api/config/js_kanban_links_config.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: links
-title: links Config
-description: You can learn about the links config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: links Config API
+description: Read the links configuration API for DHTMLX Kanban. Learn how to define task dependencies and link data between cards.
 ---
 
 # links

--- a/docs/api/config/js_kanban_locale_config.md
+++ b/docs/api/config/js_kanban_locale_config.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: locale
-title: locale Config
+title: locale Config API
 description: You can learn about the locale config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/config/js_kanban_locale_config.md
+++ b/docs/api/config/js_kanban_locale_config.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: locale
 title: locale Config API
-description: You can learn about the locale config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the locale configuration API for DHTMLX Kanban. Learn how to apply a custom locale to the board interface.
 ---
 
 # locale

--- a/docs/api/config/js_kanban_readonly_config.md
+++ b/docs/api/config/js_kanban_readonly_config.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: readonly
-title: readonly Config
-description: You can learn about the readonly config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: readonly Config API
+description: Read the readonly configuration API for DHTMLX Kanban. Learn how to disable editing and create display-only board views.
 ---
 
 # readonly

--- a/docs/api/config/js_kanban_rendertype_config.md
+++ b/docs/api/config/js_kanban_rendertype_config.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: renderType
-title: renderType Config
-description: You can learn about the renderType config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: renderType Config API
+description: Read the renderType configuration API for DHTMLX Kanban. Learn how to enable lazy rendering and optimize large boards.
 ---
 
 # renderType

--- a/docs/api/config/js_kanban_rowkey_config.md
+++ b/docs/api/config/js_kanban_rowkey_config.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: rowKey
-title: rowKey Config
-description: You can learn about the rowKey config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: rowKey Config API
+description: Read the rowKey configuration documentation for DHTMLX Kanban. Learn how to assign task cards to swimlane rows.
 ---
 
 # rowKey

--- a/docs/api/config/js_kanban_rows_config.md
+++ b/docs/api/config/js_kanban_rows_config.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: rows
-title: rows Config
-description: You can learn about the rows config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: rows Config API
+description: Read the rows configuration API for DHTMLX Kanban. Learn how to define swimlanes, row labels, limits, and horizontal board grouping.
 ---
 
 # rows

--- a/docs/api/config/js_kanban_rowshape_config.md
+++ b/docs/api/config/js_kanban_rowshape_config.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: rowShape
-title: rowShape Config
-description: You can learn about the rowShape config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: rowShape Config API
+description: Read the rowShape configuration API for DHTMLX Kanban. Learn how to customize swimlane row headers and menus.
 ---
 
 # rowShape

--- a/docs/api/config/js_kanban_scrolltype_config.md
+++ b/docs/api/config/js_kanban_scrolltype_config.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: scrollType
-title: scrollType Config
-description: You can learn about the scrollType config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: scrollType Config API
+description: Read the scrollType configuration API for DHTMLX Kanban. Learn how to configure board scrolling and column scroll behavior.
 ---
 
 # scrollType

--- a/docs/api/config/toolbar_api_config.md
+++ b/docs/api/config/toolbar_api_config.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: api
-title: api Config
+title: Toolbar api Config API
 description: You can learn about the (Toolbar) api config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/config/toolbar_api_config.md
+++ b/docs/api/config/toolbar_api_config.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: api
 title: Toolbar api Config API
-description: You can learn about the (Toolbar) api config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the Toolbar api configuration API for DHTMLX Kanban. Learn how to connect the Toolbar to the internal Kanban API.
 ---
 
 # api

--- a/docs/api/config/toolbar_items_config.md
+++ b/docs/api/config/toolbar_items_config.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: items
-title: items Config
-description: You can learn about the (Toolbar) items config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: Toolbar items Config API
+description: Read the Toolbar items configuration documentation for DHTMLX Kanban. Learn how to configure toolbar buttons, search, undo, and controls.
 ---
 
 # items

--- a/docs/api/config/toolbar_locale_config.md
+++ b/docs/api/config/toolbar_locale_config.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: locale
 title: Toolbar locale Config API
-description: You can learn about the (Toolbar) locale config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the Toolbar locale configuration API for DHTMLX Kanban. Learn how to apply a custom locale to the Toolbar.
 ---
 
 # locale

--- a/docs/api/config/toolbar_locale_config.md
+++ b/docs/api/config/toolbar_locale_config.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: locale
-title: locale Config
+title: Toolbar locale Config API
 description: You can learn about the (Toolbar) locale config in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_addcard_event.md
+++ b/docs/api/events/js_kanban_addcard_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: add-card
 title: add-card Event API
-description: You can learn about the add-card event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the add-card event API for DHTMLX Kanban. Learn how to handle the event triggered when adding a new card.
 ---
 
 # add-card

--- a/docs/api/events/js_kanban_addcard_event.md
+++ b/docs/api/events/js_kanban_addcard_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: add-card
-title: add-card Event
+title: add-card Event API
 description: You can learn about the add-card event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_addcolumn_event.md
+++ b/docs/api/events/js_kanban_addcolumn_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: add-column
-title: add-column Event
+title: add-column Event API
 description: You can learn about the add-column event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_addcolumn_event.md
+++ b/docs/api/events/js_kanban_addcolumn_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: add-column
 title: add-column Event API
-description: You can learn about the add-column event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the add-column event API for DHTMLX Kanban. Learn how to handle the event triggered when adding a new column.
 ---
 
 # add-column

--- a/docs/api/events/js_kanban_addcomment_event.md
+++ b/docs/api/events/js_kanban_addcomment_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: add-comment
-title: add-comment Event
+title: add-comment Event API
 description: You can learn about the add-comment event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_addcomment_event.md
+++ b/docs/api/events/js_kanban_addcomment_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: add-comment
 title: add-comment Event API
-description: You can learn about the add-comment event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the add-comment event API for DHTMLX Kanban. Learn how to handle the event triggered when adding a new comment.
 ---
 
 # add-comment

--- a/docs/api/events/js_kanban_addlink_event.md
+++ b/docs/api/events/js_kanban_addlink_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: add-link
 title: add-link Event API
-description: You can learn about the add-link event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the add-link event API for DHTMLX Kanban. Learn how to handle the event triggered when adding a new link.
 ---
 
 # add-link

--- a/docs/api/events/js_kanban_addlink_event.md
+++ b/docs/api/events/js_kanban_addlink_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: add-link
-title: add-link Event
+title: add-link Event API
 description: You can learn about the add-link event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_addrow_event.md
+++ b/docs/api/events/js_kanban_addrow_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: add-row
-title: add-row Event
+title: add-row Event API
 description: You can learn about the add-row event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_addrow_event.md
+++ b/docs/api/events/js_kanban_addrow_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: add-row
 title: add-row Event API
-description: You can learn about the add-row event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the add-row event API for DHTMLX Kanban. Learn how to handle the event triggered when adding a new row.
 ---
 
 # add-row

--- a/docs/api/events/js_kanban_addvote_event.md
+++ b/docs/api/events/js_kanban_addvote_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: add-vote
 title: add-vote Event API
-description: You can learn about the add-vote event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the add-vote event API for DHTMLX Kanban. Learn how to handle the event triggered when a user adds a new vote.
 ---
 
 # add-vote

--- a/docs/api/events/js_kanban_addvote_event.md
+++ b/docs/api/events/js_kanban_addvote_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: add-vote
-title: add-vote Event
+title: add-vote Event API
 description: You can learn about the add-vote event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_deletecard_event.md
+++ b/docs/api/events/js_kanban_deletecard_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: delete-card
-title: delete-card Event
+title: delete-card Event API
 description: You can learn about the delete-card event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_deletecard_event.md
+++ b/docs/api/events/js_kanban_deletecard_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: delete-card
 title: delete-card Event API
-description: You can learn about the delete-card event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the delete-card event API for DHTMLX Kanban. Learn how to handle the event triggered when removing a card.
 ---
 
 # delete-card

--- a/docs/api/events/js_kanban_deletecolumn_event.md
+++ b/docs/api/events/js_kanban_deletecolumn_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: delete-column
 title: delete-column Event API
-description: You can learn about the delete-column event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the delete-column event API for DHTMLX Kanban. Learn how to handle the event triggered when removing a column.
 ---
 
 # delete-column

--- a/docs/api/events/js_kanban_deletecolumn_event.md
+++ b/docs/api/events/js_kanban_deletecolumn_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: delete-column
-title: delete-column Event
+title: delete-column Event API
 description: You can learn about the delete-column event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_deletecomment_event.md
+++ b/docs/api/events/js_kanban_deletecomment_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: delete-comment
 title: delete-comment Event API
-description: You can learn about the delete-comment event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the delete-comment event API for DHTMLX Kanban. Learn how to handle the event triggered when deleting a card comment.
 ---
 
 # delete-comment

--- a/docs/api/events/js_kanban_deletecomment_event.md
+++ b/docs/api/events/js_kanban_deletecomment_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: delete-comment
-title: delete-comment Event
+title: delete-comment Event API
 description: You can learn about the delete-comment event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_deletelink_event.md
+++ b/docs/api/events/js_kanban_deletelink_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: delete-link
 title: delete-link Event API
-description: You can learn about the delete-link event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the delete-link event API for DHTMLX Kanban. Learn how to handle the event triggered when removing a link.
 ---
 
 # delete-link

--- a/docs/api/events/js_kanban_deletelink_event.md
+++ b/docs/api/events/js_kanban_deletelink_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: delete-link
-title: delete-link Event
+title: delete-link Event API
 description: You can learn about the delete-link event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_deleterow_event.md
+++ b/docs/api/events/js_kanban_deleterow_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: delete-row
-title: delete-row Event
+title: delete-row Event API
 description: You can learn about the delete-row event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_deleterow_event.md
+++ b/docs/api/events/js_kanban_deleterow_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: delete-row
 title: delete-row Event API
-description: You can learn about the delete-row event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the delete-row event API for DHTMLX Kanban. Learn how to handle the event triggered when removing a row.
 ---
 
 # delete-row

--- a/docs/api/events/js_kanban_deletevote_event.md
+++ b/docs/api/events/js_kanban_deletevote_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: delete-vote
-title: delete-vote Event
+title: delete-vote Event API
 description: You can learn about the delete-vote event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_deletevote_event.md
+++ b/docs/api/events/js_kanban_deletevote_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: delete-vote
 title: delete-vote Event API
-description: You can learn about the delete-vote event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the delete-vote event API for DHTMLX Kanban. Learn how to handle the event triggered when a user deletes a vote from a card.
 ---
 
 # delete-vote

--- a/docs/api/events/js_kanban_dragcard_event.md
+++ b/docs/api/events/js_kanban_dragcard_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: drag-card
-title: drag-card Event
+title: drag-card Event API
 description: You can learn about the drag-card event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_dragcard_event.md
+++ b/docs/api/events/js_kanban_dragcard_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: drag-card
 title: drag-card Event API
-description: You can learn about the drag-card event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the drag-card event API for DHTMLX Kanban. Learn how to handle the event triggered when moving the card via dnd.
 ---
 
 # drag-card

--- a/docs/api/events/js_kanban_duplicatecard_event.md
+++ b/docs/api/events/js_kanban_duplicatecard_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: duplicate-card
-title: duplicate-card Event
+title: duplicate-card Event API
 description: You can learn about the duplicate-card event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_duplicatecard_event.md
+++ b/docs/api/events/js_kanban_duplicatecard_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: duplicate-card
 title: duplicate-card Event API
-description: You can learn about the duplicate-card event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the duplicate-card event API for DHTMLX Kanban. Learn how to handle the event triggered when duplicating a card.
 ---
 
 # duplicate-card

--- a/docs/api/events/js_kanban_enddragcard_event.md
+++ b/docs/api/events/js_kanban_enddragcard_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: end-drag-card
-title: end-drag-card Event
+title: end-drag-card Event API
 description: You can learn about the end-drag-card event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_enddragcard_event.md
+++ b/docs/api/events/js_kanban_enddragcard_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: end-drag-card
 title: end-drag-card Event API
-description: You can learn about the end-drag-card event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the end-drag-card event API for DHTMLX Kanban. Learn how to handle the event triggered when stop dragging a card.
 ---
 
 # end-drag-card

--- a/docs/api/events/js_kanban_movecard_event.md
+++ b/docs/api/events/js_kanban_movecard_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: move-card
-title: move-card Event
+title: move-card Event API
 description: You can learn about the move-card event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_movecard_event.md
+++ b/docs/api/events/js_kanban_movecard_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: move-card
 title: move-card Event API
-description: You can learn about the move-card event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the move-card event API for DHTMLX Kanban. Learn how to handle the event triggered when moving a card.
 ---
 
 # move-card

--- a/docs/api/events/js_kanban_movecolumn_event.md
+++ b/docs/api/events/js_kanban_movecolumn_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: move-column
 title: move-column Event API
-description: You can learn about the move-column event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the move-column event API for DHTMLX Kanban. Learn how to handle the event triggered when moving a column.
 ---
 
 # move-column

--- a/docs/api/events/js_kanban_movecolumn_event.md
+++ b/docs/api/events/js_kanban_movecolumn_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: move-column
-title: move-column Event
+title: move-column Event API
 description: You can learn about the move-column event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_moverow_event.md
+++ b/docs/api/events/js_kanban_moverow_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: move-row
-title: move-row Event
+title: move-row Event API
 description: You can learn about the move-row event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_moverow_event.md
+++ b/docs/api/events/js_kanban_moverow_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: move-row
 title: move-row Event API
-description: You can learn about the move-row event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the move-row event API for DHTMLX Kanban. Learn how to handle the event triggered when moving a row.
 ---
 
 # move-row

--- a/docs/api/events/js_kanban_redo_event.md
+++ b/docs/api/events/js_kanban_redo_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: redo
 title: redo Event API
-description: You can learn about the redo event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the redo event API for DHTMLX Kanban. Learn how to handle the event triggered when repeating the action that was reverted by the undo action.
 ---
 
 # redo

--- a/docs/api/events/js_kanban_redo_event.md
+++ b/docs/api/events/js_kanban_redo_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: redo
-title: redo Event
+title: redo Event API
 description: You can learn about the redo event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_scroll_event.md
+++ b/docs/api/events/js_kanban_scroll_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: scroll
-title: scroll Event
+title: scroll Event API
 description: You can learn about the scroll event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_scroll_event.md
+++ b/docs/api/events/js_kanban_scroll_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: scroll
 title: scroll Event API
-description: You can learn about the scroll event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the scroll event API for DHTMLX Kanban. Learn how to handle the event triggered when scrolling to the specified elements.
 ---
 
 # scroll

--- a/docs/api/events/js_kanban_selectcard_event.md
+++ b/docs/api/events/js_kanban_selectcard_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: select-card
 title: select-card Event API
-description: You can learn about the select-card event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the select-card event API for DHTMLX Kanban. Learn how to handle the event triggered when selecting a card.
 ---
 
 # select-card

--- a/docs/api/events/js_kanban_selectcard_event.md
+++ b/docs/api/events/js_kanban_selectcard_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: select-card
-title: select-card Event
+title: select-card Event API
 description: You can learn about the select-card event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_setedit_event.md
+++ b/docs/api/events/js_kanban_setedit_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: set-edit
-title: set-edit Event
+title: set-edit Event API
 description: You can learn about the set-edit event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_setedit_event.md
+++ b/docs/api/events/js_kanban_setedit_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: set-edit
 title: set-edit Event API
-description: You can learn about the set-edit event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the set-edit event API for DHTMLX Kanban. Learn how to handle the event triggered when toggling an editor.
 ---
 
 # set-edit

--- a/docs/api/events/js_kanban_setsearch_event.md
+++ b/docs/api/events/js_kanban_setsearch_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: set-search
 title: set-search Event API
-description: You can learn about the set-search event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the set-search event API for DHTMLX Kanban. Learn how to handle the event triggered when searching for cards.
 ---
 
 # set-search

--- a/docs/api/events/js_kanban_setsearch_event.md
+++ b/docs/api/events/js_kanban_setsearch_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: set-search
-title: set-search Event
+title: set-search Event API
 description: You can learn about the set-search event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_setsort_event.md
+++ b/docs/api/events/js_kanban_setsort_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: set-sort
-title: set-sort Event
+title: set-sort Event API
 description: You can learn about the set-sort event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_setsort_event.md
+++ b/docs/api/events/js_kanban_setsort_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: set-sort
 title: set-sort Event API
-description: You can learn about the set-sort event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the set-sort event API for DHTMLX Kanban. Learn how to handle the event triggered when sorting cards.
 ---
 
 # set-sort

--- a/docs/api/events/js_kanban_startdragcard_event.md
+++ b/docs/api/events/js_kanban_startdragcard_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: start-drag-card
 title: start-drag-card Event API
-description: You can learn about the start-drag-card event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the start-drag-card event API for DHTMLX Kanban. Learn how to handle the event triggered when start dragging a card.
 ---
 
 # start-drag-card

--- a/docs/api/events/js_kanban_startdragcard_event.md
+++ b/docs/api/events/js_kanban_startdragcard_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: start-drag-card
-title: start-drag-card Event
+title: start-drag-card Event API
 description: You can learn about the start-drag-card event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_undo_event.md
+++ b/docs/api/events/js_kanban_undo_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: undo
-title: undo Event
+title: undo Event API
 description: You can learn about the undo event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_undo_event.md
+++ b/docs/api/events/js_kanban_undo_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: undo
 title: undo Event API
-description: You can learn about the undo event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the undo event API for DHTMLX Kanban. Learn how to handle the event triggered when reverting the last operation in Kanban.
 ---
 
 # undo

--- a/docs/api/events/js_kanban_unselectcard_event.md
+++ b/docs/api/events/js_kanban_unselectcard_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: unselect-card
 title: unselect-card Event API
-description: You can learn about the unselect-card event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the unselect-card event API for DHTMLX Kanban. Learn how to handle the event triggered when unselecting a card.
 ---
 
 # unselect-card

--- a/docs/api/events/js_kanban_unselectcard_event.md
+++ b/docs/api/events/js_kanban_unselectcard_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: unselect-card
-title: unselect-card Event
+title: unselect-card Event API
 description: You can learn about the unselect-card event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_updatecard_event.md
+++ b/docs/api/events/js_kanban_updatecard_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: update-card
 title: update-card Event API
-description: You can learn about the update-card event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the update-card event API for DHTMLX Kanban. Learn how to handle the event triggered when updating card data.
 ---
 
 # update-card

--- a/docs/api/events/js_kanban_updatecard_event.md
+++ b/docs/api/events/js_kanban_updatecard_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: update-card
-title: update-card Event
+title: update-card Event API
 description: You can learn about the update-card event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_updatecolumn_event.md
+++ b/docs/api/events/js_kanban_updatecolumn_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: update-column
-title: update-column Event
+title: update-column Event API
 description: You can learn about the update-column event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_updatecolumn_event.md
+++ b/docs/api/events/js_kanban_updatecolumn_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: update-column
 title: update-column Event API
-description: You can learn about the update-column event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the update-column event API for DHTMLX Kanban. Learn how to handle the event triggered when updating column data.
 ---
 
 # update-column

--- a/docs/api/events/js_kanban_updatecomment_event.md
+++ b/docs/api/events/js_kanban_updatecomment_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: update-comment
-title: update-comment Event
+title: update-comment Event API
 description: You can learn about the update-comment event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_updatecomment_event.md
+++ b/docs/api/events/js_kanban_updatecomment_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: update-comment
 title: update-comment Event API
-description: You can learn about the update-comment event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the update-comment event API for DHTMLX Kanban. Learn how to handle the event triggered when updating a comment.
 ---
 
 # update-comment

--- a/docs/api/events/js_kanban_updaterow_event.md
+++ b/docs/api/events/js_kanban_updaterow_event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: update-row
-title: update-row Event
+title: update-row Event API
 description: You can learn about the update-row event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/events/js_kanban_updaterow_event.md
+++ b/docs/api/events/js_kanban_updaterow_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: update-row
 title: update-row Event API
-description: You can learn about the update-row event in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the update-row event API for DHTMLX Kanban. Learn how to handle the event triggered when updating row data.
 ---
 
 # update-row

--- a/docs/api/internal/js_kanban_detach_method.md
+++ b/docs/api/internal/js_kanban_detach_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: api.detach()
 title: detach Method API
-description: You can learn about the detach method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the detach method API for DHTMLX Kanban. Learn how to remove or detach an event listener.
 ---
 
 # api.detach()

--- a/docs/api/internal/js_kanban_detach_method.md
+++ b/docs/api/internal/js_kanban_detach_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: api.detach()
-title: detach Method
+title: detach Method API
 description: You can learn about the detach method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/internal/js_kanban_exec_method.md
+++ b/docs/api/internal/js_kanban_exec_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: api.exec()
-title: exec Method
-description: You can learn about the exec method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: exec Method API
+description: Read the exec method API for DHTMLX Kanban. Learn how to trigger board actions and internal events programmatically.
 ---
 
 # api.exec()

--- a/docs/api/internal/js_kanban_getreactivestate_method.md
+++ b/docs/api/internal/js_kanban_getreactivestate_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: api.getReactiveState()
-title: getReactiveState Method
+title: getReactiveState Method API
 description: You can learn about the getReactiveState method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/internal/js_kanban_getreactivestate_method.md
+++ b/docs/api/internal/js_kanban_getreactivestate_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: api.getReactiveState()
 title: getReactiveState Method API
-description: You can learn about the getReactiveState method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the getReactiveState method API for DHTMLX Kanban. Learn how to get an object with the board reactive properties.
 ---
 
 # api.getReactiveState()

--- a/docs/api/internal/js_kanban_getstate_method.md
+++ b/docs/api/internal/js_kanban_getstate_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: api.getState()
-title: getState Method
-description: You can learn about the getState method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: getState Method API
+description: Read the getState method API for DHTMLX Kanban. Learn how to access current board state, cards, links, and configuration.
 ---
 
 # api.getState()

--- a/docs/api/internal/js_kanban_getstores_method.md
+++ b/docs/api/internal/js_kanban_getstores_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: api.getStores()
-title: getStores Method
+title: getStores Method API
 description: You can learn about the getStores method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/internal/js_kanban_getstores_method.md
+++ b/docs/api/internal/js_kanban_getstores_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: api.getStores()
 title: getStores Method API
-description: You can learn about the getStores method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the getStores method API for DHTMLX Kanban. Learn how to get an object with the board DataStore properties.
 ---
 
 # api.getStores()

--- a/docs/api/internal/js_kanban_intercept_method.md
+++ b/docs/api/internal/js_kanban_intercept_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: api.intercept()
-title: intercept Method
-description: You can learn about the intercept method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: intercept Method API
+description: Read the intercept method API for DHTMLX Kanban. Learn how to catch, modify, or block board events before they are applied.
 ---
 
 # api.intercept()

--- a/docs/api/internal/js_kanban_json_method.md
+++ b/docs/api/internal/js_kanban_json_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: export.json()
-title: json Method
-description: You can learn about the json method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: json Method API
+description: Read the json method API for DHTMLX Kanban. Learn how to export board data and work with JSON task structures.
 ---
 
 # export.json()

--- a/docs/api/internal/js_kanban_on_method.md
+++ b/docs/api/internal/js_kanban_on_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: api.on()
-title: on Method
-description: You can learn about the on method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: on Method API
+description: Read the on method API for DHTMLX Kanban. Learn how to subscribe to board events and handle user actions in your app.
 ---
 
 # api.on()

--- a/docs/api/internal/js_kanban_setnext_method.md
+++ b/docs/api/internal/js_kanban_setnext_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: api.setNext()
-title: setNext Method
-description: You can learn about the setNext method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: setNext Method API
+description: Read the setNext method API for DHTMLX Kanban. Learn how to connect the board API to data providers and backend flows.
 ---
 
 # api.setNext()

--- a/docs/api/methods/js_kanban_addcard_method.md
+++ b/docs/api/methods/js_kanban_addcard_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: addCard()
-title: addCard Method
+title: addCard Method API
 description: You can learn about the addCard method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_addcard_method.md
+++ b/docs/api/methods/js_kanban_addcard_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: addCard()
 title: addCard Method API
-description: You can learn about the addCard method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the addCard method API for DHTMLX Kanban. Learn how to add a new card to the board.
 ---
 
 # addCard()

--- a/docs/api/methods/js_kanban_addcolumn_method.md
+++ b/docs/api/methods/js_kanban_addcolumn_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: addColumn()
-title: addColumn Method
+title: addColumn Method API
 description: You can learn about the addColumn method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_addcolumn_method.md
+++ b/docs/api/methods/js_kanban_addcolumn_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: addColumn()
 title: addColumn Method API
-description: You can learn about the addColumn method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the addColumn method API for DHTMLX Kanban. Learn how to add a new column to the board.
 ---
 
 # addColumn()

--- a/docs/api/methods/js_kanban_addcomment_method.md
+++ b/docs/api/methods/js_kanban_addcomment_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: addComment()
 title: addComment Method API
-description: You can learn about the addComment method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the addComment method API for DHTMLX Kanban. Learn how to add a comment to a card by its ID.
 ---
 
 # addComment()

--- a/docs/api/methods/js_kanban_addcomment_method.md
+++ b/docs/api/methods/js_kanban_addcomment_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: addComment()
-title: addComment Method
+title: addComment Method API
 description: You can learn about the addComment method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_addlink_method.md
+++ b/docs/api/methods/js_kanban_addlink_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: addLink()
 title: addLink Method API
-description: You can learn about the addLink method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the addLink method API for DHTMLX Kanban. Learn how to add a new link between cards.
 ---
 
 # addLink()

--- a/docs/api/methods/js_kanban_addlink_method.md
+++ b/docs/api/methods/js_kanban_addlink_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: addLink()
-title: addLink Method
+title: addLink Method API
 description: You can learn about the addLink method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_addrow_method.md
+++ b/docs/api/methods/js_kanban_addrow_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: addRow()
 title: addRow Method API
-description: You can learn about the addRow method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the addRow method API for DHTMLX Kanban. Learn how to add a new row (swimlane) to the board.
 ---
 
 # addRow()

--- a/docs/api/methods/js_kanban_addrow_method.md
+++ b/docs/api/methods/js_kanban_addrow_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: addRow()
-title: addRow Method
+title: addRow Method API
 description: You can learn about the addRow method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_deletecard_method.md
+++ b/docs/api/methods/js_kanban_deletecard_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: deleteCard()
 title: deleteCard Method API
-description: You can learn about the deleteCard method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the deleteCard method API for DHTMLX Kanban. Learn how to remove a card from the board by its ID.
 ---
 
 # deleteCard()

--- a/docs/api/methods/js_kanban_deletecard_method.md
+++ b/docs/api/methods/js_kanban_deletecard_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: deleteCard()
-title: deleteCard Method
+title: deleteCard Method API
 description: You can learn about the deleteCard method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_deletecolumn_method.md
+++ b/docs/api/methods/js_kanban_deletecolumn_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: deleteColumn()
 title: deleteColumn Method API
-description: You can learn about the deleteColumn method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the deleteColumn method API for DHTMLX Kanban. Learn how to remove a column from the board by its ID.
 ---
 
 # deleteColumn()

--- a/docs/api/methods/js_kanban_deletecolumn_method.md
+++ b/docs/api/methods/js_kanban_deletecolumn_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: deleteColumn()
-title: deleteColumn Method
+title: deleteColumn Method API
 description: You can learn about the deleteColumn method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_deletecomment_method.md
+++ b/docs/api/methods/js_kanban_deletecomment_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: deleteComment()
-title: deleteComment Method
+title: deleteComment Method API
 description: You can learn about the deleteComment method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_deletecomment_method.md
+++ b/docs/api/methods/js_kanban_deletecomment_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: deleteComment()
 title: deleteComment Method API
-description: You can learn about the deleteComment method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the deleteComment method API for DHTMLX Kanban. Learn how to delete a card comment by its ID.
 ---
 
 # deleteComment()

--- a/docs/api/methods/js_kanban_deletelink_method.md
+++ b/docs/api/methods/js_kanban_deletelink_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: deleteLink()
-title: deleteLink Method
+title: deleteLink Method API
 description: You can learn about the deleteLink method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_deletelink_method.md
+++ b/docs/api/methods/js_kanban_deletelink_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: deleteLink()
 title: deleteLink Method API
-description: You can learn about the deleteLink method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the deleteLink method API for DHTMLX Kanban. Learn how to remove a link from the board by its ID.
 ---
 
 # deleteLink()

--- a/docs/api/methods/js_kanban_deleterow_method.md
+++ b/docs/api/methods/js_kanban_deleterow_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: deleteRow()
-title: deleteRow Method
+title: deleteRow Method API
 description: You can learn about the deleteRow method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_deleterow_method.md
+++ b/docs/api/methods/js_kanban_deleterow_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: deleteRow()
 title: deleteRow Method API
-description: You can learn about the deleteRow method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the deleteRow method API for DHTMLX Kanban. Learn how to remove a row from the board by its ID.
 ---
 
 # deleteRow()

--- a/docs/api/methods/js_kanban_destructor_method.md
+++ b/docs/api/methods/js_kanban_destructor_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: destructor()
-title: destructor Method
+title: destructor Method API
 description: You can learn about the destructor method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_destructor_method.md
+++ b/docs/api/methods/js_kanban_destructor_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: destructor()
 title: destructor Method API
-description: You can learn about the destructor method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the destructor method API for DHTMLX Kanban. Learn how to destroy the board and detach all related event listeners.
 ---
 
 # destructor()

--- a/docs/api/methods/js_kanban_duplicatecard_method.md
+++ b/docs/api/methods/js_kanban_duplicatecard_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: duplicateCard()
 title: duplicateCard Method API
-description: You can learn about the duplicateCard method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the duplicateCard method API for DHTMLX Kanban. Learn how to duplicate a card by its ID.
 ---
 
 # duplicateCard()

--- a/docs/api/methods/js_kanban_duplicatecard_method.md
+++ b/docs/api/methods/js_kanban_duplicatecard_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: duplicateCard()
-title: duplicateCard Method
+title: duplicateCard Method API
 description: You can learn about the duplicateCard method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_getareacards_method.md
+++ b/docs/api/methods/js_kanban_getareacards_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: getAreaCards()
 title: getAreaCards Method API
-description: You can learn about the getAreaCards method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the getAreaCards method API for DHTMLX Kanban. Learn how to get all cards of a column or row as an array of data objects.
 ---
 
 # getAreaCards()

--- a/docs/api/methods/js_kanban_getareacards_method.md
+++ b/docs/api/methods/js_kanban_getareacards_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: getAreaCards()
-title: getAreaCards Method
+title: getAreaCards Method API
 description: You can learn about the getAreaCards method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_getcard_method.md
+++ b/docs/api/methods/js_kanban_getcard_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: getCard()
-title: getCard Method
+title: getCard Method API
 description: You can learn about the getCard method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_getcard_method.md
+++ b/docs/api/methods/js_kanban_getcard_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: getCard()
 title: getCard Method API
-description: You can learn about the getCard method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the getCard method API for DHTMLX Kanban. Learn how to get a card data object by its ID.
 ---
 
 # getCard()

--- a/docs/api/methods/js_kanban_getcolumncards_method.md
+++ b/docs/api/methods/js_kanban_getcolumncards_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: getColumnCards()
 title: getColumnCards Method API
-description: You can learn about the getColumnCards method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the getColumnCards method API for DHTMLX Kanban. Learn how to get all cards of a column as an array of data objects.
 ---
 
 # getColumnCards()

--- a/docs/api/methods/js_kanban_getcolumncards_method.md
+++ b/docs/api/methods/js_kanban_getcolumncards_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: getColumnCards()
-title: getColumnCards Method
+title: getColumnCards Method API
 description: You can learn about the getColumnCards method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_getselection_method.md
+++ b/docs/api/methods/js_kanban_getselection_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: getSelection()
-title: getSelection Method
+title: getSelection Method API
 description: You can learn about the getSelection method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_getselection_method.md
+++ b/docs/api/methods/js_kanban_getselection_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: getSelection()
 title: getSelection Method API
-description: You can learn about the getSelection method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the getSelection method API for DHTMLX Kanban. Learn how to get the IDs of the currently selected cards.
 ---
 
 # getSelection()

--- a/docs/api/methods/js_kanban_movecard_method.md
+++ b/docs/api/methods/js_kanban_movecard_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: moveCard()
 title: moveCard Method API
-description: You can learn about the moveCard method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the moveCard method API for DHTMLX Kanban. Learn how to move a card to a specific column or row.
 ---
 
 # moveCard()

--- a/docs/api/methods/js_kanban_movecard_method.md
+++ b/docs/api/methods/js_kanban_movecard_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: moveCard()
-title: moveCard Method
+title: moveCard Method API
 description: You can learn about the moveCard method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_movecolumn_method.md
+++ b/docs/api/methods/js_kanban_movecolumn_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: moveColumn()
 title: moveColumn Method API
-description: You can learn about the moveColumn method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the moveColumn method API for DHTMLX Kanban. Learn how to move a column to a new position.
 ---
 
 # moveColumn()

--- a/docs/api/methods/js_kanban_movecolumn_method.md
+++ b/docs/api/methods/js_kanban_movecolumn_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: moveColumn()
-title: moveColumn Method
+title: moveColumn Method API
 description: You can learn about the moveColumn method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_moverow_method.md
+++ b/docs/api/methods/js_kanban_moverow_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: moveRow()
-title: moveRow Method
+title: moveRow Method API
 description: You can learn about the moveRow method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_moverow_method.md
+++ b/docs/api/methods/js_kanban_moverow_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: moveRow()
 title: moveRow Method API
-description: You can learn about the moveRow method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the moveRow method API for DHTMLX Kanban. Learn how to move a row to a new position.
 ---
 
 # moveRow()

--- a/docs/api/methods/js_kanban_parse_method.md
+++ b/docs/api/methods/js_kanban_parse_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: parse()
-title: parse Method
-description: You can learn about the parse method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: parse Method API
+description: Read the parse method API for DHTMLX Kanban. Learn how to load cards, columns, rows, and board data from JSON.
 ---
 
 # parse()

--- a/docs/api/methods/js_kanban_redo_method.md
+++ b/docs/api/methods/js_kanban_redo_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: redo()
 title: redo Method API
-description: You can learn about the redo method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the redo method API for DHTMLX Kanban. Learn how to repeat an action reverted by undo.
 ---
 
 # redo()

--- a/docs/api/methods/js_kanban_redo_method.md
+++ b/docs/api/methods/js_kanban_redo_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: redo()
-title: redo Method
+title: redo Method API
 description: You can learn about the redo method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_scroll_method.md
+++ b/docs/api/methods/js_kanban_scroll_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: scroll()
-title: scroll Method
+title: scroll Method API
 description: You can learn about the scroll method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_scroll_method.md
+++ b/docs/api/methods/js_kanban_scroll_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: scroll()
 title: scroll Method API
-description: You can learn about the scroll method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the scroll method API for DHTMLX Kanban. Learn how to scroll the board to a specific element.
 ---
 
 # scroll()

--- a/docs/api/methods/js_kanban_selectcard_method.md
+++ b/docs/api/methods/js_kanban_selectcard_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: selectCard()
 title: selectCard Method API
-description: You can learn about the selectCard method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the selectCard method API for DHTMLX Kanban. Learn how to select a card by its ID.
 ---
 
 # selectCard()

--- a/docs/api/methods/js_kanban_selectcard_method.md
+++ b/docs/api/methods/js_kanban_selectcard_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: selectCard()
-title: selectCard Method
+title: selectCard Method API
 description: You can learn about the selectCard method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_serialize_method.md
+++ b/docs/api/methods/js_kanban_serialize_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: serialize()
-title: serialize Method
+title: serialize Method API
 description: You can learn about the serialize method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_serialize_method.md
+++ b/docs/api/methods/js_kanban_serialize_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: serialize()
 title: serialize Method API
-description: You can learn about the serialize method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the serialize method API for DHTMLX Kanban. Learn how to serialize the board data to JSON.
 ---
 
 # serialize()

--- a/docs/api/methods/js_kanban_setconfig_method.md
+++ b/docs/api/methods/js_kanban_setconfig_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: setConfig()
-title: setConfig Method
-description: You can learn about the setConfig method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: setConfig Method API
+description: Read the setConfig method API for DHTMLX Kanban. Learn how to update board configuration dynamically at runtime.
 ---
 
 # setConfig()

--- a/docs/api/methods/js_kanban_setedit_method.md
+++ b/docs/api/methods/js_kanban_setedit_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: setEdit()
 title: setEdit Method API
-description: You can learn about the setEdit method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the setEdit method API for DHTMLX Kanban. Learn how to toggle the card editor.
 ---
 
 # setEdit()

--- a/docs/api/methods/js_kanban_setedit_method.md
+++ b/docs/api/methods/js_kanban_setedit_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: setEdit()
-title: setEdit Method
+title: setEdit Method API
 description: You can learn about the setEdit method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_setlocale_method.md
+++ b/docs/api/methods/js_kanban_setlocale_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: setLocale()
-title: setLocale Method
-description: You can learn about the setLocale method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: setLocale Method API
+description: Read the setLocale method API for DHTMLX Kanban. Learn how to switch interface language and configure localization.
 ---
 
 # setLocale()

--- a/docs/api/methods/js_kanban_setsearch_method.md
+++ b/docs/api/methods/js_kanban_setsearch_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: setSearch()
 title: setSearch Method API
-description: You can learn about the setSearch method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the setSearch method API for DHTMLX Kanban. Learn how to search cards by specified parameters.
 ---
 
 # setSearch()

--- a/docs/api/methods/js_kanban_setsearch_method.md
+++ b/docs/api/methods/js_kanban_setsearch_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: setSearch()
-title: setSearch Method
+title: setSearch Method API
 description: You can learn about the setSearch method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_setsort_method.md
+++ b/docs/api/methods/js_kanban_setsort_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: setSort()
-title: setSort Method
+title: setSort Method API
 description: You can learn about the setSort method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_setsort_method.md
+++ b/docs/api/methods/js_kanban_setsort_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: setSort()
 title: setSort Method API
-description: You can learn about the setSort method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the setSort method API for DHTMLX Kanban. Learn how to sort cards by specified parameters.
 ---
 
 # setSort()

--- a/docs/api/methods/js_kanban_undo_method.md
+++ b/docs/api/methods/js_kanban_undo_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: undo()
 title: undo Method API
-description: You can learn about the undo method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the undo method API for DHTMLX Kanban. Learn how to revert the last board operation.
 ---
 
 # undo()

--- a/docs/api/methods/js_kanban_undo_method.md
+++ b/docs/api/methods/js_kanban_undo_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: undo()
-title: undo Method
+title: undo Method API
 description: You can learn about the undo method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_unselectcard_method.md
+++ b/docs/api/methods/js_kanban_unselectcard_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: unselectCard()
 title: unselectCard Method API
-description: You can learn about the unselectCard method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the unselectCard method API for DHTMLX Kanban. Learn how to unselect cards by their IDs.
 ---
 
 # unselectCard()

--- a/docs/api/methods/js_kanban_unselectcard_method.md
+++ b/docs/api/methods/js_kanban_unselectcard_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: unselectCard()
-title: unselectCard Method
+title: unselectCard Method API
 description: You can learn about the unselectCard method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_updatecard_method.md
+++ b/docs/api/methods/js_kanban_updatecard_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: updateCard()
-title: updateCard Method
+title: updateCard Method API
 description: You can learn about the updateCard method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_updatecard_method.md
+++ b/docs/api/methods/js_kanban_updatecard_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: updateCard()
 title: updateCard Method API
-description: You can learn about the updateCard method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the updateCard method API for DHTMLX Kanban. Learn how to update card data by its ID.
 ---
 
 # updateCard()

--- a/docs/api/methods/js_kanban_updatecolumn_method.md
+++ b/docs/api/methods/js_kanban_updatecolumn_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: updateColumn()
-title: updateColumn Method
-description: You can learn about the updateColumn method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: updateColumn Method API
+description: Read the updateColumn method API for DHTMLX Kanban. Learn how to update column properties, styles, and menu settings.
 ---
 
 # updateColumn()

--- a/docs/api/methods/js_kanban_updatecomment_method.md
+++ b/docs/api/methods/js_kanban_updatecomment_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: updateComment()
-title: updateComment Method
+title: updateComment Method API
 description: You can learn about the updateComment method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/js_kanban_updatecomment_method.md
+++ b/docs/api/methods/js_kanban_updatecomment_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: updateComment()
 title: updateComment Method API
-description: You can learn about the updateComment method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the updateComment method API for DHTMLX Kanban. Learn how to update a card comment by its ID.
 ---
 
 # updateComment()

--- a/docs/api/methods/js_kanban_updaterow_method.md
+++ b/docs/api/methods/js_kanban_updaterow_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: updateRow()
-title: updateRow Method
-description: You can learn about the updateRow method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: updateRow Method API
+description: Read the updateRow method API for DHTMLX Kanban. Learn how to update swimlane row properties, styles, and menus.
 ---
 
 # updateRow()

--- a/docs/api/methods/toolbar_destructor_method.md
+++ b/docs/api/methods/toolbar_destructor_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: destructor()
-title: destructor Method
+title: Toolbar destructor Method API
 description: You can learn about the destructor method of Toolbar in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/toolbar_destructor_method.md
+++ b/docs/api/methods/toolbar_destructor_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: destructor()
 title: Toolbar destructor Method API
-description: You can learn about the destructor method of Toolbar in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the Toolbar destructor method API for DHTMLX Kanban. Learn how to destroy the Toolbar and detach all related event listeners.
 ---
 
 # destructor()

--- a/docs/api/methods/toolbar_setconfig_method.md
+++ b/docs/api/methods/toolbar_setconfig_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: setConfig()
-title: setConfig Method
+title: Toolbar setConfig Method API
 description: You can learn about the setConfig method of Toolbar in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/methods/toolbar_setconfig_method.md
+++ b/docs/api/methods/toolbar_setconfig_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: setConfig()
 title: Toolbar setConfig Method API
-description: You can learn about the setConfig method of Toolbar in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the Toolbar setConfig method API for DHTMLX Kanban. Learn how to update Toolbar configuration at runtime.
 ---
 
 # setConfig()

--- a/docs/api/methods/toolbar_setlocale_method.md
+++ b/docs/api/methods/toolbar_setlocale_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: setLocale()
 title: Toolbar setLocale Method API
-description: You can learn about the setLocale method of Toolbar in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the Toolbar setLocale method API for DHTMLX Kanban. Learn how to apply a new locale to the Toolbar.
 ---
 
 # setLocale()

--- a/docs/api/methods/toolbar_setlocale_method.md
+++ b/docs/api/methods/toolbar_setlocale_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: setLocale()
-title: setLocale Method
+title: Toolbar setLocale Method API
 description: You can learn about the setLocale method of Toolbar in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/overview/common_settings_overview.md
+++ b/docs/api/overview/common_settings_overview.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Common settings
 title: Common Settings Overview
-description: You can have a Common settings overview of JavaScript Kanban in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Browse the common settings overview for DHTMLX Kanban. Find shared configuration properties used across the board API.
 ---
 
 # Common settings

--- a/docs/api/overview/common_settings_overview.md
+++ b/docs/api/overview/common_settings_overview.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Common settings
-title: Common settings
+title: Common Settings Overview
 description: You can have a Common settings overview of JavaScript Kanban in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/overview/events_overview.md
+++ b/docs/api/overview/events_overview.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Events overview
 title: Events Overview
-description: You can have an Events overview of JavaScript Kanban in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Browse the events overview for DHTMLX Kanban. Find all board events for cards, columns, rows, links, votes, and more.
 ---
 
 # Events overview

--- a/docs/api/overview/internal_eventbus_overview.md
+++ b/docs/api/overview/internal_eventbus_overview.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Event Bus methods
 title: Event Bus Methods Overview
-description: You can have an Internal Event Bus methods overview of JavaScript Kanban in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Browse the Event Bus methods overview for DHTMLX Kanban. Find internal methods to fire, intercept, and handle board events.
 ---
 
 # Event Bus methods

--- a/docs/api/overview/internal_eventbus_overview.md
+++ b/docs/api/overview/internal_eventbus_overview.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Event Bus methods
-title: Event Bus Methods
+title: Event Bus Methods Overview
 description: You can have an Internal Event Bus methods overview of JavaScript Kanban in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/overview/internal_export_overview.md
+++ b/docs/api/overview/internal_export_overview.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Export methods
 title: Export Methods Overview
-description: You can have an Internal Export methods overview of JavaScript Kanban in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Browse the export methods overview for DHTMLX Kanban. Find internal methods to export and serialize board data.
 ---
 
 # Export methods

--- a/docs/api/overview/internal_export_overview.md
+++ b/docs/api/overview/internal_export_overview.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Export methods
-title: Export methods
+title: Export Methods Overview
 description: You can have an Internal Export methods overview of JavaScript Kanban in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/overview/internal_rest_overview.md
+++ b/docs/api/overview/internal_rest_overview.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: RestDataProvider methods
 title: RestDataProvider Methods Overview
-description: You can have an Internal RestDataProvider methods overview of JavaScript Kanban in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Browse the RestDataProvider methods overview for DHTMLX Kanban. Find methods to load data, send requests, and manage the queue.
 ---
 
 # RestDataProvider methods

--- a/docs/api/overview/internal_rest_overview.md
+++ b/docs/api/overview/internal_rest_overview.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: RestDataProvider methods
-title: RestDataProvider methods
+title: RestDataProvider Methods Overview
 description: You can have an Internal RestDataProvider methods overview of JavaScript Kanban in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/overview/internal_state_overview.md
+++ b/docs/api/overview/internal_state_overview.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: State methods
 title: State Methods Overview
-description: You can have an Internal State methods overview of JavaScript Kanban in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Browse the state methods overview for DHTMLX Kanban. Find internal methods to access reactive state, stores, and configuration.
 ---
 
 # State methods

--- a/docs/api/overview/internal_state_overview.md
+++ b/docs/api/overview/internal_state_overview.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: State methods
-title: State methods
+title: State Methods Overview
 description: You can have an Internal State methods overview of JavaScript Kanban in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/overview/main_overview.md
+++ b/docs/api/overview/main_overview.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: API overview
-title: API Overview
-description: You can have an API overview of JavaScript Kanban in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: Kanban API Overview
+description: Browse the DHTMLX Kanban API overview. Find configuration references, methods, events, toolbar APIs, and developer documentation.
 ---
 
 # API overview

--- a/docs/api/overview/methods_overview.md
+++ b/docs/api/overview/methods_overview.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Methods overview
 title: Methods Overview
-description: You can have a Methods overview of JavaScript Kanban in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Browse the methods overview for DHTMLX Kanban. Find all board methods to add, update, move, and delete cards, columns, and rows.
 ---
 
 # Methods overview

--- a/docs/api/overview/properties_overview.md
+++ b/docs/api/overview/properties_overview.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Properties overview
 title: Properties Overview
-description: You can have a Properties overview of JavaScript Kanban in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Browse the properties overview for DHTMLX Kanban. Find all configuration properties for cards, columns, rows, and editor.
 ---
 
 # Kanban properties overview

--- a/docs/api/overview/rest_routes_overview.md
+++ b/docs/api/overview/rest_routes_overview.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: REST routes overview
-title: REST routes overview
+title: REST Routes Overview
 description: You can have an Internal RestDataProvider routes overview of JavaScript Kanban in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/overview/rest_routes_overview.md
+++ b/docs/api/overview/rest_routes_overview.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: REST routes overview
 title: REST Routes Overview
-description: You can have an Internal RestDataProvider routes overview of JavaScript Kanban in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Browse the REST routes overview for DHTMLX Kanban. Find all backend endpoints for cards, columns, rows, links, comments, and votes.
 ---
 
 # REST routes overview

--- a/docs/api/overview/toolbar_methods_overview.md
+++ b/docs/api/overview/toolbar_methods_overview.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Toolbar methods overview
 title: Toolbar Methods Overview
-description: You can have a Toolbar methods overview of JavaScript Kanban in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Browse the Toolbar methods overview for DHTMLX Kanban. Find methods to configure, localize, and destroy the Toolbar.
 ---
 
 # Toolbar methods overview

--- a/docs/api/overview/toolbar_properties_overview.md
+++ b/docs/api/overview/toolbar_properties_overview.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Toolbar properties overview
 title: Toolbar Properties Overview
-description: You can have a Toolbar Properties overview of JavaScript Kanban in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Browse the Toolbar properties overview for DHTMLX Kanban. Find configuration properties for the Toolbar items and API.
 ---
 
 # Toolbar properties overview

--- a/docs/api/provider/rest_methods/js_kanban_getcards_method.md
+++ b/docs/api/provider/rest_methods/js_kanban_getcards_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: getCards()
-title: getCards REST Method
+title: getCards REST Method API
 description: You can learn about the getCards REST method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_methods/js_kanban_getcards_method.md
+++ b/docs/api/provider/rest_methods/js_kanban_getcards_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: getCards()
 title: getCards REST Method API
-description: You can learn about the getCards REST method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the getCards REST method API for DHTMLX Kanban. Learn how to get a promise with cards data.
 ---
 
 # getCards()

--- a/docs/api/provider/rest_methods/js_kanban_getcolumns_method.md
+++ b/docs/api/provider/rest_methods/js_kanban_getcolumns_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: getColumns()
 title: getColumns REST Method API
-description: You can learn about the getColumns REST method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the getColumns REST method API for DHTMLX Kanban. Learn how to get a promise with columns data.
 ---
 
 # getColumns()

--- a/docs/api/provider/rest_methods/js_kanban_getcolumns_method.md
+++ b/docs/api/provider/rest_methods/js_kanban_getcolumns_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: getColumns()
-title: getColumns REST Method
+title: getColumns REST Method API
 description: You can learn about the getColumns REST method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_methods/js_kanban_gethandlers_method.md
+++ b/docs/api/provider/rest_methods/js_kanban_gethandlers_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: getHandlers()
 title: getHandlers REST Method API
-description: You can learn about the getHandlers REST method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the getHandlers REST method API for DHTMLX Kanban. Learn how to get the default action handlers used to send operations to the server.
 ---
 
 # getHandlers()

--- a/docs/api/provider/rest_methods/js_kanban_gethandlers_method.md
+++ b/docs/api/provider/rest_methods/js_kanban_gethandlers_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: getHandlers()
-title: getHandlers REST Method
+title: getHandlers REST Method API
 description: You can learn about the getHandlers REST method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_methods/js_kanban_getidresolver_method.md
+++ b/docs/api/provider/rest_methods/js_kanban_getidresolver_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: getIDResolver()
 title: getIDResolver REST Method API
-description: You can learn about the getIDResolver REST method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the getIDResolver REST method API for DHTMLX Kanban. Learn how to resolve temporary client-side IDs to backend IDs.
 ---
 
 # getIDResolver()

--- a/docs/api/provider/rest_methods/js_kanban_getidresolver_method.md
+++ b/docs/api/provider/rest_methods/js_kanban_getidresolver_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: getIDResolver()
-title: getIDResolver REST Method
+title: getIDResolver REST Method API
 description: You can learn about the getIDResolver REST method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_methods/js_kanban_getlinks_method.md
+++ b/docs/api/provider/rest_methods/js_kanban_getlinks_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: getLinks()
 title: getLinks REST Method API
-description: You can learn about the getLinks REST method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the getLinks REST method API for DHTMLX Kanban. Learn how to get a promise with links data.
 ---
 
 # getLinks()

--- a/docs/api/provider/rest_methods/js_kanban_getlinks_method.md
+++ b/docs/api/provider/rest_methods/js_kanban_getlinks_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: getLinks()
-title: getLinks REST Method
+title: getLinks REST Method API
 description: You can learn about the getLinks REST method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_methods/js_kanban_getqueue_method.md
+++ b/docs/api/provider/rest_methods/js_kanban_getqueue_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: getQueue()
 title: getQueue REST Method API
-description: You can learn about the getQueue REST method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the getQueue REST method API for DHTMLX Kanban. Learn how to get the internal queue of actions RestDataProvider processes.
 ---
 
 # getQueue()

--- a/docs/api/provider/rest_methods/js_kanban_getqueue_method.md
+++ b/docs/api/provider/rest_methods/js_kanban_getqueue_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: getQueue()
-title: getQueue REST Method
+title: getQueue REST Method API
 description: You can learn about the getQueue REST method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_methods/js_kanban_getrows_method.md
+++ b/docs/api/provider/rest_methods/js_kanban_getrows_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: getRows()
-title: getRows REST Method
+title: getRows REST Method API
 description: You can learn about the getRows REST method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_methods/js_kanban_getrows_method.md
+++ b/docs/api/provider/rest_methods/js_kanban_getrows_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: getRows()
 title: getRows REST Method API
-description: You can learn about the getRows REST method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the getRows REST method API for DHTMLX Kanban. Learn how to get a promise with rows data.
 ---
 
 # getRows()

--- a/docs/api/provider/rest_methods/js_kanban_getusers_method.md
+++ b/docs/api/provider/rest_methods/js_kanban_getusers_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: getUsers()
-title: getUsers REST Method
+title: getUsers REST Method API
 description: You can learn about the getUsers REST method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_methods/js_kanban_getusers_method.md
+++ b/docs/api/provider/rest_methods/js_kanban_getusers_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: getUsers()
 title: getUsers REST Method API
-description: You can learn about the getUsers REST method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the getUsers REST method API for DHTMLX Kanban. Learn how to get a promise with users data.
 ---
 
 # getUsers()

--- a/docs/api/provider/rest_methods/js_kanban_send_method.md
+++ b/docs/api/provider/rest_methods/js_kanban_send_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: send()
-title: send() Method
+title: send REST Method API
 description: You can learn about the send() method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_methods/js_kanban_send_method.md
+++ b/docs/api/provider/rest_methods/js_kanban_send_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: send()
 title: send REST Method API
-description: You can learn about the send() method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the send REST method API for DHTMLX Kanban. Learn how to send an HTTP request to the server and get a promise with the response.
 ---
 
 # send()

--- a/docs/api/provider/rest_methods/js_kanban_setheaders_method.md
+++ b/docs/api/provider/rest_methods/js_kanban_setheaders_method.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: setHeaders()
 title: setHeaders REST Method API
-description: You can learn about the setHeaders REST method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the setHeaders REST method API for DHTMLX Kanban. Learn how to set custom HTTP headers attached to every request.
 ---
 
 # setHeaders()

--- a/docs/api/provider/rest_methods/js_kanban_setheaders_method.md
+++ b/docs/api/provider/rest_methods/js_kanban_setheaders_method.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: setHeaders()
-title: setHeaders REST Method
+title: setHeaders REST Method API
 description: You can learn about the setHeaders REST method in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_routes/delete_routes/js_kanban_delete_cards_comments_route.md
+++ b/docs/api/provider/rest_routes/delete_routes/js_kanban_delete_cards_comments_route.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: DELETE /cards/{id}/comments/{id}
 title: DELETE /cards/{cardId}/comments/{commentId} REST Route API
-description: You can learn about the DELETE /cards/{cardId}/comments/{commentId} REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the DELETE /cards/{cardId}/comments/{commentId} REST route API for DHTMLX Kanban. Learn how to remove a comment from a card.
 ---
 
 # DELETE `/cards/{cardId}/comments/{commentId}`

--- a/docs/api/provider/rest_routes/delete_routes/js_kanban_delete_cards_comments_route.md
+++ b/docs/api/provider/rest_routes/delete_routes/js_kanban_delete_cards_comments_route.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: DELETE /cards/{id}/comments/{id}
-title: DELETE /cards/{cardId}/comments/{commentId}
+title: DELETE /cards/{cardId}/comments/{commentId} REST Route API
 description: You can learn about the DELETE /cards/{cardId}/comments/{commentId} REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_routes/delete_routes/js_kanban_delete_cards_route.md
+++ b/docs/api/provider/rest_routes/delete_routes/js_kanban_delete_cards_route.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: DELETE /cards
-title: DELETE /cards
+title: DELETE /cards REST Route API
 description: You can learn about the DELETE /cards REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_routes/delete_routes/js_kanban_delete_cards_route.md
+++ b/docs/api/provider/rest_routes/delete_routes/js_kanban_delete_cards_route.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: DELETE /cards
 title: DELETE /cards REST Route API
-description: You can learn about the DELETE /cards REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the DELETE /cards REST route API for DHTMLX Kanban. Learn how to delete a card.
 ---
 
 # DELETE `/cards`

--- a/docs/api/provider/rest_routes/delete_routes/js_kanban_delete_cards_votes_route.md
+++ b/docs/api/provider/rest_routes/delete_routes/js_kanban_delete_cards_votes_route.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: DELETE /cards/{id}/vote
 title: DELETE /cards/{cardId}/vote REST Route API
-description: You can learn about the DELETE /cards/{cardId}/vote REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the DELETE /cards/{cardId}/vote REST route API for DHTMLX Kanban. Learn how to remove a vote from a card.
 ---
 
 # DELETE `/cards/{cardId}/vote`

--- a/docs/api/provider/rest_routes/delete_routes/js_kanban_delete_cards_votes_route.md
+++ b/docs/api/provider/rest_routes/delete_routes/js_kanban_delete_cards_votes_route.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: DELETE /cards/{id}/vote
-title: DELETE /cards/{cardId}/vote
+title: DELETE /cards/{cardId}/vote REST Route API
 description: You can learn about the DELETE /cards/{cardId}/vote REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_routes/delete_routes/js_kanban_delete_columns_route.md
+++ b/docs/api/provider/rest_routes/delete_routes/js_kanban_delete_columns_route.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: DELETE /columns
-title: DELETE /columns
+title: DELETE /columns REST Route API
 description: You can learn about the DELETE /columns REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_routes/delete_routes/js_kanban_delete_columns_route.md
+++ b/docs/api/provider/rest_routes/delete_routes/js_kanban_delete_columns_route.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: DELETE /columns
 title: DELETE /columns REST Route API
-description: You can learn about the DELETE /columns REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the DELETE /columns REST route API for DHTMLX Kanban. Learn how to delete a column.
 ---
 
 # DELETE `/columns`

--- a/docs/api/provider/rest_routes/delete_routes/js_kanban_delete_links_route.md
+++ b/docs/api/provider/rest_routes/delete_routes/js_kanban_delete_links_route.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: DELETE /links
-title: DELETE /links
+title: DELETE /links REST Route API
 description: You can learn about the DELETE /links REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_routes/delete_routes/js_kanban_delete_links_route.md
+++ b/docs/api/provider/rest_routes/delete_routes/js_kanban_delete_links_route.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: DELETE /links
 title: DELETE /links REST Route API
-description: You can learn about the DELETE /links REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the DELETE /links REST route API for DHTMLX Kanban. Learn how to delete a link.
 ---
 
 # DELETE `/links`

--- a/docs/api/provider/rest_routes/delete_routes/js_kanban_delete_rows_route.md
+++ b/docs/api/provider/rest_routes/delete_routes/js_kanban_delete_rows_route.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: DELETE /rows
-title: DELETE /rows
+title: DELETE /rows REST Route API
 description: You can learn about the DELETE /rows REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_routes/delete_routes/js_kanban_delete_rows_route.md
+++ b/docs/api/provider/rest_routes/delete_routes/js_kanban_delete_rows_route.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: DELETE /rows
 title: DELETE /rows REST Route API
-description: You can learn about the DELETE /rows REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the DELETE /rows REST route API for DHTMLX Kanban. Learn how to delete a row (swimlane).
 ---
 
 # DELETE `/rows`

--- a/docs/api/provider/rest_routes/get_routes/js_kanban_get_cards_route.md
+++ b/docs/api/provider/rest_routes/get_routes/js_kanban_get_cards_route.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: GET /cards
-title: GET /cards
+title: GET /cards REST Route API
 description: You can learn about the GET /cards REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_routes/get_routes/js_kanban_get_cards_route.md
+++ b/docs/api/provider/rest_routes/get_routes/js_kanban_get_cards_route.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: GET /cards
 title: GET /cards REST Route API
-description: You can learn about the GET /cards REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the GET /cards REST route API for DHTMLX Kanban. Learn how to get data on all cards as a JSON array.
 ---
 
 # GET `/cards`

--- a/docs/api/provider/rest_routes/get_routes/js_kanban_get_columns_route.md
+++ b/docs/api/provider/rest_routes/get_routes/js_kanban_get_columns_route.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: GET /columns
-title: GET /columns
+title: GET /columns REST Route API
 description: You can learn about the GET /columns REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_routes/get_routes/js_kanban_get_columns_route.md
+++ b/docs/api/provider/rest_routes/get_routes/js_kanban_get_columns_route.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: GET /columns
 title: GET /columns REST Route API
-description: You can learn about the GET /columns REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the GET /columns REST route API for DHTMLX Kanban. Learn how to get data on all columns as a JSON array.
 ---
 
 # GET `/columns`

--- a/docs/api/provider/rest_routes/get_routes/js_kanban_get_links_route.md
+++ b/docs/api/provider/rest_routes/get_routes/js_kanban_get_links_route.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: GET /links
-title: GET /links
+title: GET /links REST Route API
 description: You can learn about the GET /links REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_routes/get_routes/js_kanban_get_links_route.md
+++ b/docs/api/provider/rest_routes/get_routes/js_kanban_get_links_route.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: GET /links
 title: GET /links REST Route API
-description: You can learn about the GET /links REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the GET /links REST route API for DHTMLX Kanban. Learn how to get data on all links as a JSON array.
 ---
 
 # GET `/links`

--- a/docs/api/provider/rest_routes/get_routes/js_kanban_get_rows_route.md
+++ b/docs/api/provider/rest_routes/get_routes/js_kanban_get_rows_route.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: GET /rows
-title: GET /rows
+title: GET /rows REST Route API
 description: You can learn about the GET /rows REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_routes/get_routes/js_kanban_get_rows_route.md
+++ b/docs/api/provider/rest_routes/get_routes/js_kanban_get_rows_route.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: GET /rows
 title: GET /rows REST Route API
-description: You can learn about the GET /rows REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the GET /rows REST route API for DHTMLX Kanban. Learn how to get data on all rows (swimlanes) as a JSON array.
 ---
 
 # GET `/rows`

--- a/docs/api/provider/rest_routes/get_routes/js_kanban_get_uploads_route.md
+++ b/docs/api/provider/rest_routes/get_routes/js_kanban_get_uploads_route.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: GET /uploads
 title: GET /uploads REST Route API
-description: You can learn about the GET /uploads REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the GET /uploads REST route API for DHTMLX Kanban. Learn how to get a requested binary file from the server.
 ---
 
 # GET `/uploads`

--- a/docs/api/provider/rest_routes/get_routes/js_kanban_get_uploads_route.md
+++ b/docs/api/provider/rest_routes/get_routes/js_kanban_get_uploads_route.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: GET /uploads
-title: GET /uploads
+title: GET /uploads REST Route API
 description: You can learn about the GET /uploads REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_routes/get_routes/js_kanban_get_users_route.md
+++ b/docs/api/provider/rest_routes/get_routes/js_kanban_get_users_route.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: GET /users
 title: GET /users REST Route API
-description: You can learn about the GET /users REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the GET /users REST route API for DHTMLX Kanban. Learn how to get data on all users as a JSON array.
 ---
 
 # GET `/users`

--- a/docs/api/provider/rest_routes/get_routes/js_kanban_get_users_route.md
+++ b/docs/api/provider/rest_routes/get_routes/js_kanban_get_users_route.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: GET /users
-title: GET /users
+title: GET /users REST Route API
 description: You can learn about the GET /users REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_routes/post_routes/js_kanban_post_cards_comments_route.md
+++ b/docs/api/provider/rest_routes/post_routes/js_kanban_post_cards_comments_route.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: POST /cards/{id}/comments
 title: POST /cards/{cardId}/comments REST Route API
-description: You can learn about the POST /cards/{cardId}/comments REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the POST /cards/{cardId}/comments REST route API for DHTMLX Kanban. Learn how to add a new comment to a card and return the new comment ID.
 ---
 
 # POST `/cards/{cardId}/comments`

--- a/docs/api/provider/rest_routes/post_routes/js_kanban_post_cards_comments_route.md
+++ b/docs/api/provider/rest_routes/post_routes/js_kanban_post_cards_comments_route.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: POST /cards/{id}/comments
-title: POST /cards/{cardId}/comments
+title: POST /cards/{cardId}/comments REST Route API
 description: You can learn about the POST /cards/{cardId}/comments REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_routes/post_routes/js_kanban_post_cards_route.md
+++ b/docs/api/provider/rest_routes/post_routes/js_kanban_post_cards_route.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: POST /cards
 title: POST /cards REST Route API
-description: You can learn about the POST /cards REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the POST /cards REST route API for DHTMLX Kanban. Learn how to create a new card and return its new ID.
 ---
 
 # POST `/cards`

--- a/docs/api/provider/rest_routes/post_routes/js_kanban_post_cards_route.md
+++ b/docs/api/provider/rest_routes/post_routes/js_kanban_post_cards_route.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: POST /cards
-title: POST /cards
+title: POST /cards REST Route API
 description: You can learn about the POST /cards REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_routes/post_routes/js_kanban_post_cards_votes_route.md
+++ b/docs/api/provider/rest_routes/post_routes/js_kanban_post_cards_votes_route.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: POST /cards/{id}/vote
 title: POST /cards/{cardId}/vote REST Route API
-description: You can learn about the POST /cards/{cardId}/vote REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the POST /cards/{cardId}/vote REST route API for DHTMLX Kanban. Learn how to add a vote to a card and return the voting user ID.
 ---
 
 # POST `/cards/{cardId}/vote`

--- a/docs/api/provider/rest_routes/post_routes/js_kanban_post_cards_votes_route.md
+++ b/docs/api/provider/rest_routes/post_routes/js_kanban_post_cards_votes_route.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: POST /cards/{id}/vote
-title: POST /cards/{cardId}/vote
+title: POST /cards/{cardId}/vote REST Route API
 description: You can learn about the POST /cards/{cardId}/vote REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_routes/post_routes/js_kanban_post_columns_route.md
+++ b/docs/api/provider/rest_routes/post_routes/js_kanban_post_columns_route.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: POST /columns
-title: POST /columns
+title: POST /columns REST Route API
 description: You can learn about the POST /columns REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_routes/post_routes/js_kanban_post_columns_route.md
+++ b/docs/api/provider/rest_routes/post_routes/js_kanban_post_columns_route.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: POST /columns
 title: POST /columns REST Route API
-description: You can learn about the POST /columns REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the POST /columns REST route API for DHTMLX Kanban. Learn how to create a new column and return its ID.
 ---
 
 # POST `/columns`

--- a/docs/api/provider/rest_routes/post_routes/js_kanban_post_links_route.md
+++ b/docs/api/provider/rest_routes/post_routes/js_kanban_post_links_route.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: POST /links
-title: POST /links
+title: POST /links REST Route API
 description: You can learn about the POST /links REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_routes/post_routes/js_kanban_post_links_route.md
+++ b/docs/api/provider/rest_routes/post_routes/js_kanban_post_links_route.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: POST /links
 title: POST /links REST Route API
-description: You can learn about the POST /links REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the POST /links REST route API for DHTMLX Kanban. Learn how to create a new link and return its new ID.
 ---
 
 # POST `/links`

--- a/docs/api/provider/rest_routes/post_routes/js_kanban_post_rows_route.md
+++ b/docs/api/provider/rest_routes/post_routes/js_kanban_post_rows_route.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: POST /rows
-title: POST /rows
+title: POST /rows REST Route API
 description: You can learn about the POST /rows REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_routes/post_routes/js_kanban_post_rows_route.md
+++ b/docs/api/provider/rest_routes/post_routes/js_kanban_post_rows_route.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: POST /rows
 title: POST /rows REST Route API
-description: You can learn about the POST /rows REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the POST /rows REST route API for DHTMLX Kanban. Learn how to create a new row and return its ID.
 ---
 
 # POST /rows

--- a/docs/api/provider/rest_routes/post_routes/js_kanban_post_uploads_route.md
+++ b/docs/api/provider/rest_routes/post_routes/js_kanban_post_uploads_route.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: POST /uploads
-title: POST /uploads
+title: POST /uploads REST Route API
 description: You can learn about the POST /uploads REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_routes/post_routes/js_kanban_post_uploads_route.md
+++ b/docs/api/provider/rest_routes/post_routes/js_kanban_post_uploads_route.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: POST /uploads
 title: POST /uploads REST Route API
-description: You can learn about the POST /uploads REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the POST /uploads REST route API for DHTMLX Kanban. Learn how to upload a binary file and return its ID, name, and URL.
 ---
 
 # POST `/uploads`

--- a/docs/api/provider/rest_routes/put_routes/js_kanban_put_cards_comments_route.md
+++ b/docs/api/provider/rest_routes/put_routes/js_kanban_put_cards_comments_route.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: PUT /cards/{id}/comments/{id}
-title: PUT /cards/{cardId}/comments/{commentId}
+title: PUT /cards/{cardId}/comments/{commentId} REST Route API
 description: You can learn about the PUT /cards/{cardId}/comments/{cardId} REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_routes/put_routes/js_kanban_put_cards_comments_route.md
+++ b/docs/api/provider/rest_routes/put_routes/js_kanban_put_cards_comments_route.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: PUT /cards/{id}/comments/{id}
 title: PUT /cards/{cardId}/comments/{commentId} REST Route API
-description: You can learn about the PUT /cards/{cardId}/comments/{cardId} REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the PUT /cards/{cardId}/comments/{commentId} REST route API for DHTMLX Kanban. Learn how to update a card comment and return its ID.
 ---
 
 # PUT `/cards/{cardId}/comments/{commentId}`

--- a/docs/api/provider/rest_routes/put_routes/js_kanban_put_cards_move_route.md
+++ b/docs/api/provider/rest_routes/put_routes/js_kanban_put_cards_move_route.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: PUT /cards/{id}/move
-title: PUT /cards/{id}/move
+title: PUT /cards/{id}/move REST Route API
 description: You can learn about the PUT /cards/{id}/move REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_routes/put_routes/js_kanban_put_cards_move_route.md
+++ b/docs/api/provider/rest_routes/put_routes/js_kanban_put_cards_move_route.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: PUT /cards/{id}/move
 title: PUT /cards/{id}/move REST Route API
-description: You can learn about the PUT /cards/{id}/move REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the PUT /cards/{id}/move REST route API for DHTMLX Kanban. Learn how to move cards to a specified position.
 ---
 
 # PUT `/cards/{id}/move`

--- a/docs/api/provider/rest_routes/put_routes/js_kanban_put_cards_route.md
+++ b/docs/api/provider/rest_routes/put_routes/js_kanban_put_cards_route.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: PUT /cards
-title: PUT /cards
+title: PUT /cards REST Route API
 description: You can learn about the PUT /cards REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_routes/put_routes/js_kanban_put_cards_route.md
+++ b/docs/api/provider/rest_routes/put_routes/js_kanban_put_cards_route.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: PUT /cards
 title: PUT /cards REST Route API
-description: You can learn about the PUT /cards REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the PUT /cards REST route API for DHTMLX Kanban. Learn how to update data on a card.
 ---
 
 # PUT `/cards`

--- a/docs/api/provider/rest_routes/put_routes/js_kanban_put_columns_move_route.md
+++ b/docs/api/provider/rest_routes/put_routes/js_kanban_put_columns_move_route.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: PUT /columns/{id}/move
-title: PUT /columns/{id}/move
+title: PUT /columns/{id}/move REST Route API
 description: You can learn about the PUT /columns/{id}/move REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_routes/put_routes/js_kanban_put_columns_move_route.md
+++ b/docs/api/provider/rest_routes/put_routes/js_kanban_put_columns_move_route.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: PUT /columns/{id}/move
 title: PUT /columns/{id}/move REST Route API
-description: You can learn about the PUT /columns/{id}/move REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the PUT /columns/{id}/move REST route API for DHTMLX Kanban. Learn how to move a column to a specified position.
 ---
 
 # PUT `/columns/{id}/move`

--- a/docs/api/provider/rest_routes/put_routes/js_kanban_put_columns_route.md
+++ b/docs/api/provider/rest_routes/put_routes/js_kanban_put_columns_route.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: PUT /columns
-title: PUT /columns
+title: PUT /columns REST Route API
 description: You can learn about the PUT /columns REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_routes/put_routes/js_kanban_put_columns_route.md
+++ b/docs/api/provider/rest_routes/put_routes/js_kanban_put_columns_route.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: PUT /columns
 title: PUT /columns REST Route API
-description: You can learn about the PUT /columns REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the PUT /columns REST route API for DHTMLX Kanban. Learn how to update data on a column.
 ---
 
 # PUT `/columns`

--- a/docs/api/provider/rest_routes/put_routes/js_kanban_put_rows_move_route.md
+++ b/docs/api/provider/rest_routes/put_routes/js_kanban_put_rows_move_route.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: PUT /rows/{id}/move
 title: PUT /rows/{id}/move REST Route API
-description: You can learn about the PUT /rows/{id}/move REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the PUT /rows/{id}/move REST route API for DHTMLX Kanban. Learn how to move a row to a specified position.
 ---
 
 # PUT `/rows/{id}/move`

--- a/docs/api/provider/rest_routes/put_routes/js_kanban_put_rows_move_route.md
+++ b/docs/api/provider/rest_routes/put_routes/js_kanban_put_rows_move_route.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: PUT /rows/{id}/move
-title: PUT /rows/{id}/move
+title: PUT /rows/{id}/move REST Route API
 description: You can learn about the PUT /rows/{id}/move REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/api/provider/rest_routes/put_routes/js_kanban_put_rows_route.md
+++ b/docs/api/provider/rest_routes/put_routes/js_kanban_put_rows_route.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: PUT /rows
 title: PUT /rows REST Route API
-description: You can learn about the PUT /rows REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read the PUT /rows REST route API for DHTMLX Kanban. Learn how to update data on a row (swimlane).
 ---
 
 # PUT `/rows`

--- a/docs/api/provider/rest_routes/put_routes/js_kanban_put_rows_route.md
+++ b/docs/api/provider/rest_routes/put_routes/js_kanban_put_rows_route.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: PUT /rows
-title: PUT /rows
+title: PUT /rows REST Route API
 description: You can learn about the PUT /rows REST route in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
 ---
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Configuration
-title: Configuration
-description: You can learn about the configuration in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: Kanban Configuration Guide
+description: Read the DHTMLX Kanban configuration guide. Learn how to set up cards, columns, rows, editor, toolbar, and other board elements.
 ---
 
 # Configuration

--- a/docs/guides/customization.md
+++ b/docs/guides/customization.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Customization
-title: Customization
-description: You can learn about the customization in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: Kanban Customization Guide
+description: Use DHTMLX Kanban customization guides to modify templates, menus, cards, columns, and board behavior with documented API templates.
 ---
 
 # Customization

--- a/docs/guides/initialization.md
+++ b/docs/guides/initialization.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Initialization
-title: Initialization
-description: You can learn about the initialization in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: Kanban Initialization Guide
+description: Follow the DHTMLX Kanban initialization guide. Learn constructor setup, required configuration, columns, cards, and board initialization.
 ---
 
 # Initialization

--- a/docs/guides/integration.md
+++ b/docs/guides/integration.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Integration with DHTMLX widgets
-title: Integration with DHTMLX widgets
-description: You can learn about the integration in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: DHTMLX Widgets - Kanban Integration Guide
+description: Follow the DHTMLX Kanban integration guide for DHTMLX Gantt, Event Calendar, and To Do List widgets. Learn how to combine Kanban with Gantt and other DHTMLX components in one app.
 ---
 
 # Integration with DHTMLX widgets

--- a/docs/guides/integration_with_angular.md
+++ b/docs/guides/integration_with_angular.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Integration with Angular
-title: Integration with Angular
-description: You can learn about the integration with Angular in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: Angular Kanban Integration Guide
+description: Follow the DHTMLX Kanban Angular integration guide. Learn component setup, configuration, API usage, and project structure.
 ---
 
 # Integration with Angular

--- a/docs/guides/integration_with_react.md
+++ b/docs/guides/integration_with_react.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Integration with React
-title: Integration with React
-description: You can learn about the integration with React in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: React Kanban Integration Guide
+description: Follow the DHTMLX Kanban React integration guide. Learn component setup, configuration, API usage, and lifecycle handling.
 ---
 
 # Integration with React

--- a/docs/guides/integration_with_salesforce.md
+++ b/docs/guides/integration_with_salesforce.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Integration with Salesforce
-title: Integration with Salesforce
+title: Salesforce Kanban Integration Guide
 description: Learn how to integrate DHTMLX Kanban into Salesforce. This guide explains the required HTML setup and environment configuration for smooth operation inside Salesforce Lightning components.
 ---
 

--- a/docs/guides/integration_with_svelte.md
+++ b/docs/guides/integration_with_svelte.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Integration with Svelte
-title: Integration with Svelte
-description: You can learn about the integration with Svelte in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: Svelte Kanban Integration Guide
+description: Follow the DHTMLX Kanban Svelte integration guide. Learn setup, configuration, API usage, and component lifecycle patterns.
 ---
 
 # Integration with Svelte

--- a/docs/guides/integration_with_vue.md
+++ b/docs/guides/integration_with_vue.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Integration with Vue
-title: Integration with Vue
-description: You can learn about the integration with Vue in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: Vue Kanban Integration Guide
+description: Follow the DHTMLX Kanban Vue integration guide. Learn component setup, configuration, API usage, and app integration.
 ---
 
 # Integration with Vue

--- a/docs/guides/localization.md
+++ b/docs/guides/localization.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Localization
-title: Localization
-description: You can learn about the localization in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: Kanban Localization Guide
+description: Read the DHTMLX Kanban localization guide. Learn locale configuration, language packs, setLocale usage, and multilingual UI setup.
 ---
 
 # Localization

--- a/docs/guides/stylization.md
+++ b/docs/guides/stylization.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Stylization
-title: Stylization
-description: You can learn about the stylization in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: Kanban Stylization Guide
+description: Read the DHTMLX Kanban stylization guide. Learn how to style cards, columns, and rows with CSS classes and CSS variables.
 ---
 
 # Stylization

--- a/docs/guides/typescript_support.md
+++ b/docs/guides/typescript_support.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: TypeScript support
-title: TypeScript support
-description: You can learn about using typescript with the DHTMLX JavaScript Kanban library in the documentation. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: Kanban TypeScript Support Guide
+description: Follow the DHTMLX Kanban TypeScript support guide. Learn how to use the built-in type definitions and typed configuration in your TypeScript project.
 ---
 
 # TypeScript support

--- a/docs/guides/working_with_data.md
+++ b/docs/guides/working_with_data.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Working with data
-title: Working with Data
-description: You can explore how to work with Data in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: Kanban Data Parsing Guide
+description: Read the DHTMLX Kanban data parsing guide. Learn how to load, read, export, and update cards, columns, rows, links, and comments on the board.
 ---
 
 # Working with data

--- a/docs/guides/working_with_server.md
+++ b/docs/guides/working_with_server.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Working with server
-title: Working with Server
-description: You can explore how to work with Server in the documentation of the DHTMLX JavaScript Kanban library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+title: Kanban Server Integration Guide
+description: Read the DHTMLX Kanban server integration guide. Learn REST data providers, backend sync, remote events, and API configuration.
 ---
 
 # Working with server

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Kanban overview
-title: DHTMLX API & Guides
+title: JavaScript Kanban API & Guides
 slug: /
 description: Read DHTMLX JavaScript Kanban documentation with API reference, developer guides, configuration options, and examples for building Kanban boards.
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
 ---
 sidebar_label: Kanban overview
-title: JavaScript Kanban Overview
+title: DHTMLX API & Guides
 slug: /
-description: You can have an overview of DHTMLX JavaScript Kanban library in the documentation. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Kanban.
+description: Read DHTMLX JavaScript Kanban documentation with API reference, developer guides, configuration options, and examples for building Kanban boards.
 ---
 
 # DHTMLX Kanban overview

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -194,8 +194,8 @@ const onAfterDataTransformation = (data) => {
 /** @type {import('@docusaurus/types').Config} */
 const config = {
 	noIndex: false,
-	title: 'DHTMLX JavaScript Kanban Docs',
-	tagline: 'DHTMLX JavaScript Kanban Docs', 
+	title: 'DHTMLX Kanban Documentation',
+	tagline: 'DHTMLX Kanban Documentation',
 	url: 'https://docs.dhtmlx.com',
 	baseUrl: process.env.DOCUSAURUS_BASEURL || '/kanban/',
 	i18n: {


### PR DESCRIPTION
- apply recommended titles/descriptions from "Kanban task Meta" sheet
- unify <title> patterns across the whole API reference: Config/Event/Method/REST Method/REST Route + Parameter, all "... API"
- prefix Toolbar setConfig/setLocale/destructor to avoid duplicate titles
- normalize all 14 guide titles to "{Topic} Kanban Guide" / "{Tech} Kanban Integration Guide" and rewrite boilerplate descriptions
- change global site title to "DHTMLX Kanban Documentation" so Docusaurus appends a single brand suffix without doubling